### PR TITLE
chore(labeler): 🔧 Update `ghaction-github-labeler` to version `v5`

### DIFF
--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5.3.0
+        uses: crazy-max/ghaction-github-labeler@v5
         with:
           skip-delete: true


### PR DESCRIPTION
* Updated the action to use the latest stable version.
* Ensures compatibility and access to the latest features and fixes.