### PR TITLE
fix(translation): Minor fixes

### DIFF
--- a/custom_components/iopool/translations/fr.json
+++ b/custom_components/iopool/translations/fr.json
@@ -18,7 +18,7 @@
                 "data": {
                     "api_key": "Clé API"
                 },
-                "description": "Récupérez votre clé API dans l'application IOPool :\n1. Ouvrez l'application IOPool\n2. Allez dans Paramètres > Clé API\n3. Copiez la clé API et collez-la ici.",
+                "description": "Récupérez votre clé API dans l'application IOPool :\n1. Ouvrez l'application IOPool\n2. Allez dans Paramètres > Clé d'API\n3. Copiez la clé API et collez-la ici.",
                 "title": "Configuration iopool"
             },
             "choose_pool": {
@@ -30,7 +30,7 @@
             },
             "reconfigure": {
               "title": "Configuration iopool",
-              "description": "Récupérez votre clé API dans l'application IOPool :\n1. Ouvrez l'application IOPool\n2. Allez dans Paramètres > Clé API\n3. Copiez la clé API et collez-la ici.",
+              "description": "Récupérez votre clé API dans l'application IOPool :\n1. Ouvrez l'application IOPool\n2. Allez dans Paramètres > Clé d'API\n3. Copiez la clé API et collez-la ici.",
               "data": {
                 "api_key": "Clé API"
               }

--- a/custom_components/iopool/translations/fr.json
+++ b/custom_components/iopool/translations/fr.json
@@ -125,22 +125,10 @@
         },
         "select": {
             "boost_selector": {
-                "name": "Sélecteur Boost",
-                "state": {
-                    "None": "Aucun",
-                    "1H": "1 Heure",
-                    "4H": "4 Heures",
-                    "8H": "8 Heures",
-                    "24H": "24 Heures"
-                }
+                "name": "Sélecteur Boost"
             },
             "pool_mode": {
-                "name": "Mode piscine",
-                "state": {
-                    "Standard": "Standard",
-                    "Active-Winter": "Hivernage actif",
-                    "Passive-Winter": "Hivernage passif"
-                }
+                "name": "Mode piscine"
             }
         }
     }


### PR DESCRIPTION
This pull request makes updates to the French translation file `fr.json` for the `iopool` custom component, focusing on improving translation accuracy and simplifying certain sections.

### Translation improvements:
* Updated the term "Clé API" to "Clé d'API" in the descriptions under both the main configuration and reconfiguration sections for consistency and correctness. [[1]](diffhunk://#diff-fa551ec37448e949c222644588bf1abe32d1f79615a42b05a0a23718551ebf7cL21-R21) [[2]](diffhunk://#diff-fa551ec37448e949c222644588bf1abe32d1f79615a42b05a0a23718551ebf7cL33-R33)

### Simplification of translation structure:
* Removed unused or unnecessary state mappings for "Sélecteur Boost" and "Mode piscine" to streamline the translation file. These mappings were likely redundant or no longer required.