### PR TITLE
feat: Add 2H boost option to filtration control

### DIFF
--- a/custom_components/iopool/select.py
+++ b/custom_components/iopool/select.py
@@ -30,7 +30,7 @@ from .models import IopoolConfigData, IopoolConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-BOOST_OPTIONS: Final = ["None", "1H", "4H", "8H", "24H"]
+BOOST_OPTIONS: Final = ["None", "1H", "2H", "4H", "8H", "24H"]
 MODE_OPTIONS: Final = ["Standard", "Active-Winter", "Passive-Winter"]
 
 # Entity descriptions for each pool
@@ -262,7 +262,7 @@ class IopoolSelect(IopoolEntity, SelectEntity):
 
             # If a boost time is selected, schedule end time
             if option != "None":
-                # Parse the boost duration (1H, 4H, 8H, 24H)
+                # Parse the boost duration (1H, 2H, 4H, 8H, 24H)
                 match = re.match(r"(\d+)H", option)
                 if match:
                     hours = int(match.group(1))

--- a/docs/faq/index.mdx
+++ b/docs/faq/index.mdx
@@ -50,7 +50,7 @@ For all other texts (UI, menus, etc.), the translation is based on your user pro
 ### How does Boost mode work?
 
 <Accordion title="How to use Boost" icon="bolt">
-Boost mode allows you to temporarily increase filtration for 1h, 4h, 8h, or 24h.  
+Boost mode allows you to temporarily increase filtration for 1h, 2h, 4h, 8h, or 24h.  
 You can activate Boost via the `Boost Selector` entity in Home Assistant or through automations.
 </Accordion>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -55,7 +55,7 @@ This integration is an independent development and is not affiliated with the io
   - Summer and winter modes with configurable schedules and durations
   - Two summer slots with percentage-based duration split
   - Minimum and maximum duration constraints
-- **Boost Mode**: Temporarily increase filtration for 1h, 4h, 8h, or 24h
+- **Boost Mode**: Temporarily increase filtration for 1h, 2h, 4h, 8h, or 24h
 - **Filtration State Tracking**: Real-time binary sensor reflecting pump state
 - **History Stats**: Daily elapsed filtration duration sensor
 - **Multi-language**: English and French translations

--- a/docs/integration/entities.mdx
+++ b/docs/integration/entities.mdx
@@ -21,7 +21,7 @@ The iopool integration creates a device for each pool detected through the API, 
 | Elapsed Filtration Duration (sensor) | Total filtration time elapsed today (in minutes)                                      | **Advanced**: Only if filtration automation is enabled            |
 | Action Required (binary_sensor)     | Indicates if maintenance action is needed                                              | Always                                                            |
 | Filtration (binary_sensor)          | Indicates if the filtration system is currently running                                | **Advanced**: Only if filtration automation is enabled            |
-| Boost Selector (select)             | Allows temporary boost of filtration (1h, 4h, 8h, 24h)                                 | **Advanced**: Only if filtration automation is enabled            |
+| Boost Selector (select)             | Allows temporary boost of filtration (1h, 2h, 4h, 8h, 24h)                                 | **Advanced**: Only if filtration automation is enabled            |
 | Pool Mode (select)                  | Allows switching between Standard, Active-Winter, Passive-Winter modes                 | **Advanced**: Only if filtration automation is enabled            |
 
 <Info>
@@ -135,7 +135,7 @@ Indicates if the filtration system is currently running.
 
 ## Boost Selector (Advanced)
 
-Allows you to temporarily increase filtration for 1h, 4h, 8h, or 24h.
+Allows you to temporarily increase filtration for 1h, 2h, 4h, 8h, or 24h.
 
 <Info>
 **This select entity is only available if filtration automation is enabled and a switch entity is configured in the integration options.**
@@ -144,6 +144,7 @@ Allows you to temporarily increase filtration for 1h, 4h, 8h, or 24h.
 Options :
 - `None`
 - `1H`
+- `2H`
 - `4H`
 - `8H`
 - `24H`

--- a/docs/integration/events.mdx
+++ b/docs/integration/events.mdx
@@ -167,7 +167,7 @@ Depending on the event type, the `data` field contains:
   - `start_time`: ISO8601 datetime when filtration started
   - `end_time`: ISO8601 datetime when filtration ended
   - `duration_minutes`: Duration of the slot/winter filtration in minutes
-  - `boost_in_progress`: Current boost state (`None`, `1H`, `4H`, etc.)
+  - `boost_in_progress`: Current boost state (`None`, `1H`, `2H`, `4H`, etc.)
   - `remaining_boost_duration_minutes`: Minutes left in boost (if any)
   - `day_filtration_objective_minutes`: Target filtration duration for the day
   - `day_filtration_elapsed_minutes`: Elapsed filtration time for the day

--- a/docs/integration/setup.mdx
+++ b/docs/integration/setup.mdx
@@ -86,7 +86,7 @@ The iopool integration will automatically create the following entities for each
 
 ### Select Entities
 
-- **Boost Selector** (`select.iopool_*_boost_selector`): Allows you to temporarily increase filtration for 1h, 4h, 8h, or 24h  
+- **Boost Selector** (`select.iopool_*_boost_selector`): Allows you to temporarily increase filtration for 1h, 2h, 4h, 8h, or 24h  
   <small>_Only available if filtration automation is enabled and a switch entity is configured in the integration options._</small>
 - **Pool Mode** (`select.iopool_*_pool_mode`): Allows you to switch between Standard, Active-Winter, and Passive-Winter modes  
   <small>_Only available if filtration automation is enabled and a switch entity is configured in the integration options._</small>


### PR DESCRIPTION
This pull request updates the `Boost Mode` functionality in the `iopool` integration to include a new 2-hour (`2H`) option for temporary filtration boosts. Changes span across the code implementation and documentation to ensure consistency (Issue #7).

### Code Implementation Updates:
* [`custom_components/iopool/select.py`](diffhunk://#diff-7ac0f06b4ae4238609f3c5cd8650557f597957cf4de1cb5aa4ddc16e760c3c3fL33-R33): Added `2H` as a valid option in the `BOOST_OPTIONS` constant and updated the parsing logic to handle the new duration. [[1]](diffhunk://#diff-7ac0f06b4ae4238609f3c5cd8650557f597957cf4de1cb5aa4ddc16e760c3c3fL33-R33) [[2]](diffhunk://#diff-7ac0f06b4ae4238609f3c5cd8650557f597957cf4de1cb5aa4ddc16e760c3c3fL265-R265)

### Documentation Updates:
* [`docs/faq/index.mdx`](diffhunk://#diff-080b51bc7769f243741bd774fd930307b2265921ba3d1e8d3c46c03321b36326L53-R53): Updated the description of Boost mode to include the new `2H` option.
* [`docs/index.mdx`](diffhunk://#diff-135108c7d936a6d1e05ce4ecaa854c5dccdea8ad5d317e08d61639b9ffbc6425L58-R58): Revised the Boost mode feature description to reflect the addition of the `2H` option.
* [`docs/integration/entities.mdx`](diffhunk://#diff-30c89679d21c15168d6cdd33cb8b00d72733afafa59b673c53609ef1a4c5c644L24-R24): Updated multiple sections to include `2H` in the list of Boost mode options, including the entity description and advanced selector details. [[1]](diffhunk://#diff-30c89679d21c15168d6cdd33cb8b00d72733afafa59b673c53609ef1a4c5c644L24-R24) [[2]](diffhunk://#diff-30c89679d21c15168d6cdd33cb8b00d72733afafa59b673c53609ef1a4c5c644L138-R138) [[3]](diffhunk://#diff-30c89679d21c15168d6cdd33cb8b00d72733afafa59b673c53609ef1a4c5c644R147)
* [`docs/integration/events.mdx`](diffhunk://#diff-d6f7bde8d70a3caf9ee6f76bd7cfa7cddcbc331d5aa9dacdf1dab531703f1cd8L170-R170): Included `2H` in the `boost_in_progress` field description for integration events.
* [`docs/integration/setup.mdx`](diffhunk://#diff-48204d31827f106f2d54e2d8a869230eda68de8bb28d91a66da3ef168eab8e65L89-R89): Updated the Boost Selector entity description to include the new `2H` option.