### PR TITLE
feat(sensor): ✨ Expose display_precision attribute for sensors

### DIFF
--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -280,6 +280,19 @@ class IopoolSensor(IopoolEntity, SensorEntity):
                 }
             )
 
+        # If the entity description suggests a display precision, expose it
+        # as an attribute so frontends or automations can use it.
+        try:
+            precision = getattr(
+                self.entity_description, "suggested_display_precision", None
+            )
+        except Exception:
+            precision = None
+
+        if precision is not None:
+            # Ensure we return a plain int (or similar) in attributes
+            attributes["display_precision"] = int(precision)
+
         return attributes
 
     def _get_pool(self) -> IopoolAPIResponsePool | None:

--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -282,13 +282,9 @@ class IopoolSensor(IopoolEntity, SensorEntity):
 
         # If the entity description suggests a display precision, expose it
         # as an attribute so frontends or automations can use it.
-        try:
-            precision = getattr(
-                self.entity_description, "suggested_display_precision", None
-            )
-        except Exception:
-            precision = None
-
+        precision = getattr(
+            self.entity_description, "suggested_display_precision", None
+        )
         if precision is not None:
             # Ensure we return a plain int (or similar) in attributes
             attributes["display_precision"] = int(precision)

--- a/docs/integration/custom-card.mdx
+++ b/docs/integration/custom-card.mdx
@@ -38,6 +38,12 @@ This page explains how to add a custom dashboard card for your iopool integratio
     </Step> 
 </Steps>
 
+<Warning>
+There is currently an [open issue](https://github.com/wilsto/pool-monitor-card/issues/68) with the [Pool Monitor Card](https://github.com/wilsto/pool-monitor-card) that causes values to display with excessive decimal places.
+A new feature addressing this was added in [commit](https://github.com/wilsto/pool-monitor-card/commit/2043581f48138560ca82eac57835dcea084924a6), but it has not yet been released in a production version.
+The iopool integration is already prepared for this update and exposes `display_precision` for each sensor where `suggested_display_precision` is set.
+</Warning>
+
 <Image src="/images/dashboard-card.png" alt="Dashboard Card" />
 
 

--- a/docs/integration/custom-card.mdx
+++ b/docs/integration/custom-card.mdx
@@ -38,8 +38,6 @@ This page explains how to add a custom dashboard card for your iopool integratio
     </Step> 
 </Steps>
 
-<Warning>There is currently a [bug](https://github.com/wilsto/pool-monitor-card/issues/68) in the [Pool Monitor Card](https://github.com/wilsto/pool-monitor-card) that displays too many decimal.</Warning>
-
 <Image src="/images/dashboard-card.png" alt="Dashboard Card" />
 
 

--- a/docs/integration/entities.mdx
+++ b/docs/integration/entities.mdx
@@ -42,6 +42,7 @@ The ideal temperature depends on the type of pool or spa and personal preference
 - `measured_at`: Timestamp of when the measurement was taken
 - `is_valid`: Boolean indicating if the measurement is considered valid
 - `measure_mode`: The mode in which the measurement was taken (standard, live, maintenance, etc.)
+- `display_precision`: Number of decimal places used when displaying the temperature value (e.g., `1` for 25.3°C, `0` for 25°C)
 
 ---
 
@@ -54,9 +55,10 @@ The recommended pH level for swimming pools is between 7.1 and 7.7. Maintaining 
 </Info>
 
 **Attributes:**
-- `measured_at`
-- `is_valid`
-- `measure_mode`
+- `measured_at`: Timestamp of when the pH measurement was taken
+- `is_valid`: Boolean indicating if the pH measurement is considered valid
+- `measure_mode`: The mode in which the pH measurement was taken (standard, live, maintenance, etc.)
+- `display_precision`: Number of decimal places used when displaying the pH value (e.g., `2` for 7.34, `1` for 7.3)
 
 ---
 
@@ -69,9 +71,9 @@ The ideal ORP range for swimming pools is between 650mV and 800mV. An ORP level 
 </Info>
 
 **Attributes:**
-- `measured_at`
-- `is_valid`
-- `measure_mode`
+- `measured_at`: Timestamp of when the ORP measurement was taken
+- `is_valid`: Boolean indicating if the ORP measurement is considered valid
+- `measure_mode`: The mode in which the ORP measurement was taken (standard, live, maintenance, etc.)
 
 ---
 


### PR DESCRIPTION
This pull request adds support for exposing the `display_precision` attribute for pool sensors in the iopool integration, allowing frontends and automations to display sensor values with the appropriate number of decimal places. It also updates documentation to reflect this new feature and improves test coverage to ensure correct behavior for sensors with and without a suggested display precision.
With this feature, iopool integration is already ready for the [upcoming feature](https://github.com/wilsto/pool-monitor-card/commit/2043581f48138560ca82eac57835dcea084924a6) in Pool Monitor Card.

**Sensor attribute enhancements:**

* The `extra_state_attributes` method in `sensor.py` now includes a `display_precision` attribute for sensors where `entity_description.suggested_display_precision` is set, making it available for use in frontends and automations.

**Testing improvements:**

* Updated and added tests in `test_sensor.py` to verify that `display_precision` is correctly included or omitted for sensors depending on whether `suggested_display_precision` is set. [[1]](diffhunk://#diff-c8a8e8b19ca42c899b93fcebfa3137424a3fe71ac3c497d371cc3f027b6a95ebR707-R709) [[2]](diffhunk://#diff-c8a8e8b19ca42c899b93fcebfa3137424a3fe71ac3c497d371cc3f027b6a95ebL728-R782)

**Documentation updates:**

* The custom card documentation now explains the `display_precision` feature and its relevance to the Pool Monitor Card, noting that the iopool integration is ready for the upcoming card update.
* The entities documentation was updated to describe the new `display_precision` attribute for temperature and pH sensors, and clarify its absence for ORP sensors. [[1]](diffhunk://#diff-30c89679d21c15168d6cdd33cb8b00d72733afafa59b673c53609ef1a4c5c644R45) [[2]](diffhunk://#diff-30c89679d21c15168d6cdd33cb8b00d72733afafa59b673c53609ef1a4c5c644L57-R61) [[3]](diffhunk://#diff-30c89679d21c15168d6cdd33cb8b00d72733afafa59b673c53609ef1a4c5c644L72-R76)