### PR TITLE
chore(beta): 🔧 Sync dev into beta

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/home-assistant.yaml
+++ b/.github/workflows/home-assistant.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Hassfest Validation
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v5"
+        - uses: "actions/checkout@v6"
         - uses: "home-assistant/actions/hassfest@master"
 
   validate-hacs:

--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run Labeler
         uses: crazy-max/ghaction-github-labeler@v5

--- a/.github/workflows/lock-stale.yml
+++ b/.github/workflows/lock-stale.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'mguyard'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5.0.1
+      - uses: dessant/lock-threads@v6.0.0
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '30'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       name: Semver #your environment name
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Install semantic-release

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,7 +64,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py${{ matrix.python-version }}-hass-${{ matrix.home-assistant-version }}-${{ hashFiles('custom_components/iopool/manifest.json') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Download last tested beta version
         if: matrix.home-assistant-version == 'beta' && github.event_name == 'schedule'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: last-tested-beta-version
           path: /tmp/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -281,7 +281,7 @@ jobs:
 
       - name: Upload tested beta version record
         if: matrix.home-assistant-version == 'beta' && env.SKIP_TESTS != 'true' && github.event_name == 'schedule'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: last-tested-beta-version
           path: /tmp/last-tested-beta.txt
@@ -307,7 +307,7 @@ jobs:
 
       - name: Upload test results
         if: always() && env.SKIP_TESTS != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-py${{ matrix.python-version }}-ha${{ matrix.home-assistant-version }}
           path: |


### PR DESCRIPTION
## Summary

This PR merges the `dev` branch into `beta`, bringing the following changes:

---

### chore(deps): GitHub Actions dependencies updates

The following GitHub Actions dependencies have been updated to their latest major versions (all migrated to Node.js 24 runtime):

- **`chore(deps): 🔧 bump dessant/lock-threads from 5.0.1 to 6.0.0`**
  Commit: https://github.com/mguyard/hass-iopool/commit/249636b899f83b3f9dad8b0eea6d3af9f6a84d12

- **`chore(deps): 🔧 bump actions/checkout from 5 to 6`** (PR #39)
  Commit: https://github.com/mguyard/hass-iopool/commit/137b2d90589338dc26fb426c6fe10cc338f1c1ab

- **`chore(deps): 🔧 bump actions/cache from 4 to 5`** (PR #40)
  Commit: https://github.com/mguyard/hass-iopool/commit/00be03d5aaa85563fb572e8b176367e8cea5f3fa

- **`chore(deps): 🔧 bump actions/upload-artifact from 4 to 6`** (PR #41)
  Commit: https://github.com/mguyard/hass-iopool/commit/d3f4d227d24ae9180349f86c0bd33dc3624a7b12

- **`chore(deps): 🔧 bump actions/download-artifact from 5 to 7`** (PR #42)
  Commit: https://github.com/mguyard/hass-iopool/commit/ac4e8c3c938566a9b3905c7d0f6649e7ba6b9d1a

---

> All changes are GitHub Actions workflow dependency updates (Dependabot). No integration code has been modified.