### PR TITLE
chore(release): 🔧 Release 1.2.2 — CI workflow improvements & Copilot customizations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,13 +16,79 @@
 - **Documentation:**  
   - All files in `docs/` and `docs.json` are documentation and must use the `docs` commit type.
   - Documentation is in Markdown or MDX, and must be clear and concise.
+  - Entity reference: `docs/integration/entities.mdx` — keep it up to date when adding/removing entities.
 - **Testing:**  
-  - Use `pytest` conventions for tests (if/when present).
-  - Place tests in a `tests/` directory.
-  - **Always suggest adding or updating tests when new features or bug fixes are implemented.**
+  - Use `pytest` conventions for tests.
+  - Tests live in `custom_components/iopool/tests/`.
+  - **Always add or update tests when implementing features or bug fixes.**
 - **Linting/Formatting:**  
-  - Use `flake8` as the linter, with a maximum line length of 150 characters (see `.vscode/settings.json`).
-  - You may also use `black` for formatting if desired, but `flake8` is required for linting.
+  - Use `flake8` as the linter, with a maximum line length of 150 characters.
+  - You may also use `black` for formatting, but `flake8` is required for linting.
+
+## Dev Environment & Commands
+
+> Tests require a full Home Assistant dev container (`/workspaces/home-assistant-dev`).
+
+```bash
+# Run all tests (from within the HA dev container)
+cd /workspaces/home-assistant-dev/config
+PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/
+
+# Verbose with short tracebacks
+PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ -v --tb=short
+
+# With coverage
+PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ --cov=. --cov-report=term-missing
+
+# Shortcut scripts (auto-configure PYTHONPATH)
+./custom_components/iopool/tests/run_tests.sh
+./custom_components/iopool/run_tests.sh
+
+# Lint
+flake8 custom_components/iopool/ --max-line-length=150
+```
+
+> ⚠️ **Never create a `pytest.ini`** file — it breaks async test discovery. Config lives in `pyproject.toml` (`asyncio_mode = "auto"`).
+
+## Architecture
+
+### Data Flow
+
+```
+Config Flow → ConfigEntry.runtime_data (IopoolData)
+                    ├── coordinator  (IopoolDataUpdateCoordinator)  — polls API every 5 min
+                    ├── filtration   (Filtration)                   — time-based scheduling
+                    └── setup_time_events                           — callback reference
+```
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `__init__.py` | Entry setup, platform loading, runtime_data assembly |
+| `coordinator.py` | `DataUpdateCoordinator` — fetches `IopoolAPIResponse` |
+| `api_models.py` | Dataclass models for raw API responses |
+| `models.py` | `IopoolData`, `IopoolConfigData`, filtration option dataclasses |
+| `const.py` | All constants: domain, sensor keys, event types, API URLs |
+| `entity.py` | `IopoolEntity(CoordinatorEntity, RestoreEntity)` base class |
+| `sensor.py` | Sensor platform (temperature, pH, ORP, mode, recommendations) |
+| `binary_sensor.py` | Binary sensor platform (action required, filtration active) |
+| `select.py` | Select platform (boost selector, pool mode selectors) |
+| `filtration.py` | Time-based filtration slot scheduling (`async_track_time_change`) |
+
+### Platform Loading Order
+
+```python
+PLATFORMS = [Platform.SENSOR, Platform.SELECT, Platform.BINARY_SENSOR]
+```
+
+⚠️ **Order matters:** `sensor` must load before `binary_sensor`; filtration entities have a dependency on it.
+
+### Manifest Highlights
+
+- **Domain:** `iopool` | **IoT class:** `cloud_polling` | **Type:** `hub`
+- **Quality scale:** `bronze` | **Dependencies:** `["cloud", "history_stats"]`
+- **Docs:** https://docs.page/mguyard/hass-iopool
 
 ## External Context and Libraries
 
@@ -131,30 +197,7 @@
 - When generating commit messages, follow the Conventional Commits and gitmoji rules above.
 - When working with Home Assistant, prefer async APIs and follow the entity/component patterns in the codebase.
 - All configuration, code, and documentation must be consistent with the existing project structure and standards.
-- **Always suggest adding or updating tests for new features or bug fixes.**
+- **Always add or update tests when implementing features or bug fixes.**
 - **Enforce flake8 linting with a max line length of 150 characters.**
-
----
-
-These instructions are designed to help GitHub Copilot and Copilot Coding Agent generate code, documentation, and commit messages that are consistent with the project's standards and best practices.
-- Prefer list comprehensions and generator expressions for concise code.
-- Avoid global variables.
-- Use constants for configuration values.
-
-## Home Assistant Integration
-
-- Follow [Home Assistant custom component guidelines](https://developers.home-assistant.io/docs/creating_component_index/).
-- Entities should have unique IDs and meaningful names.
-- Use translations for entity names and options.
-- Ensure all entities are documented in `docs/integration/entities.mdx`.
-
-## For Copilot Coding Agent
-
-- When asked to create or modify files, always use English for code, comments, and docstrings.
-- When generating documentation, use Markdown or MDX and English.
-- When generating commit messages, follow the Conventional Commits and gitmoji rules above.
-- When working with Home Assistant, prefer async APIs and follow the entity/component patterns in the codebase.
-- All configuration, code, and documentation must be consistent with the existing project structure and standards.
-
----
-These instructions are designed to help GitHub Copilot and Copilot Coding Agent generate code, documentation, and commit messages that are consistent with the project's standards and best practices.
+- Before editing code, read the relevant file(s) to understand existing patterns.
+- When adding a new entity, update `docs/integration/entities.mdx` and both translation files (`en.json`, `fr.json`).

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,83 @@
+---
+description: "Use when creating or editing documentation files in docs/ or docs.json. Covers MDX format, frontmatter structure, navigation, commit conventions, and the docs.page platform."
+applyTo: "docs/**, docs.json"
+---
+
+# Documentation Guidelines
+
+## Format
+
+All documentation files use **MDX** (Markdown + JSX). Do not use plain `.md` files in `docs/`.
+
+Every MDX file must start with YAML frontmatter:
+
+```mdx
+---
+title: Page Title
+description: One-line summary shown in search results and meta tags
+previous: /integration/previous-page
+previousTitle: Previous Page
+next: /integration/next-page
+nextTitle: Next Page
+---
+```
+
+`title` and `description` are required. `previous`/`next` are required for pages in a sequential flow.
+
+## Commit Convention
+
+Any change to `docs/` or `docs.json` must use the `docs` commit type:
+
+```
+docs(entities): 📝 Add salinity sensor to entity reference
+```
+
+Never mix documentation changes with code changes in the same commit.
+
+## `docs/integration/entities.mdx` — Entity Reference
+
+This file is the **single source of truth for all HA entities**. Keep it up to date whenever you add or remove an entity.
+
+Table format:
+```mdx
+| Entity Name (type) | Description | Availability |
+|--|--|--|
+| Temperature (sensor) | The water temperature in °C | Always |
+| Filtration (binary sensor) | Whether the pump is running | Always |
+| Boost Selector (select) | Set a temporary filtration boost | Always |
+```
+
+- Column 1: `Display Name (entity type)` — must match the translation name exactly
+- Column 2: Plain English description of what the entity represents
+- Column 3: When it is available (`Always`, `When filtration enabled`, etc.)
+
+Use `<Info>` blocks for tips and callouts:
+```mdx
+<Info>
+All entities are refreshed every `5 minutes` by default.
+</Info>
+```
+
+## `docs.json` — Navigation Structure
+
+`docs.json` controls the sidebar and tab navigation on docs.page. When adding a new page:
+
+1. Create the `.mdx` file at the correct path under `docs/`.
+2. Add the page to the `sidebar` array in `docs.json` under the appropriate group:
+
+```json
+{
+  "title": "My New Page",
+  "href": "/integration/my-new-page",
+  "icon": "optional-lucide-icon-name"
+}
+```
+
+Do not duplicate page entries or create orphan pages (pages not referenced in `docs.json`).
+
+## Language and Style
+
+- All documentation must be in **English**.
+- Write for end users, not developers — avoid internal code references unless necessary.
+- Keep descriptions short and factual.
+- Link to the official docs site when referencing the integration: https://docs.page/mguyard/hass-iopool

--- a/.github/instructions/new-entity.instructions.md
+++ b/.github/instructions/new-entity.instructions.md
@@ -1,0 +1,102 @@
+---
+description: "Use when adding, removing, or modifying a Home Assistant entity in the iopool integration. Covers sensor, binary_sensor, and select platforms, constants, translations, documentation, and test checklist."
+---
+
+# New Entity Checklist
+
+Follow every step below whenever you add or remove an entity from the integration.
+
+## 1. Add the constant in `const.py`
+
+```python
+# ALL_CAPS constant name, snake_case string value
+SENSOR_MY_FEATURE = "my_feature"
+```
+
+The string value becomes the entity's `unique_id` suffix and the translation key.
+
+## 2. Add the entity description in the correct platform file
+
+Choose the file that matches the entity type:
+
+| Type | File | Description class |
+|------|------|-------------------|
+| Sensor | `sensor.py` | `SensorEntityDescription` |
+| Binary sensor | `binary_sensor.py` | `BinarySensorEntityDescription` |
+| Select | `select.py` | `SelectEntityDescription` |
+
+**Sensor example:**
+```python
+SensorEntityDescription(
+    key=SENSOR_MY_FEATURE,           # constant from const.py
+    translation_key=SENSOR_MY_FEATURE,  # same as key — always
+    icon="mdi:icon-name",            # MDI icon — required
+    device_class=SensorDeviceClass.X,   # optional, use HA device class
+    state_class=SensorStateClass.X,     # optional
+    native_unit_of_measurement=...,     # optional
+),
+```
+
+`translation_key` must always match `key`.
+
+## 3. Add translation keys in both `translations/en.json` and `translations/fr.json`
+
+The key path is `entity.{platform}.{key_name}.name`.
+
+**en.json:**
+```json
+{
+  "entity": {
+    "sensor": {
+      "my_feature": { "name": "My Feature" }
+    }
+  }
+}
+```
+
+**fr.json** — provide the French translation:
+```json
+{
+  "entity": {
+    "sensor": {
+      "my_feature": { "name": "Ma Fonctionnalité" }
+    }
+  }
+}
+```
+
+If the entity has `state` options (e.g., select), add them under `state`:
+```json
+"my_feature": {
+  "name": "My Feature",
+  "state": {
+    "option_key": "Displayed Label"
+  }
+}
+```
+
+## 4. Update `docs/integration/entities.mdx`
+
+Add a row to the entities table:
+```mdx
+| My Feature (sensor) | Description of what it measures | Always |
+```
+
+- Column 1: `Name (type)` — must match the entity name from translations
+- Column 2: Short description
+- Column 3: Availability condition (`Always`, `When filtration active`, etc.)
+
+## 5. Write or update tests
+
+- Add tests in the matching `tests/test_{platform}.py` file.
+- Cover: entity setup, `native_value` / `is_on`, extra state attributes, unavailable state.
+- Use existing fixtures from `conftest.py` and `conftest_hass.py`.
+- Follow the `class TestIopoolXxxPlatform:` naming pattern.
+
+## 6. Verify platform loading order
+
+`PLATFORMS` in `__init__.py` **must** remain:
+```python
+PLATFORMS = [Platform.SENSOR, Platform.SELECT, Platform.BINARY_SENSOR]
+```
+Do not change this order — `binary_sensor` depends on `sensor` being loaded first.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,101 @@
+---
+description: "Use when writing, running, or debugging tests for the iopool integration. Covers test environment setup, fixture usage, async patterns, and coverage expectations."
+applyTo: "custom_components/iopool/tests/**/*.py"
+---
+
+# Testing Guidelines
+
+## Environment
+
+Tests **require** a Home Assistant dev container. Always set `PYTHONPATH`:
+
+```bash
+# From /workspaces/home-assistant-dev/config
+PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/
+
+# Or use the shortcut scripts (auto-configure PYTHONPATH)
+./custom_components/iopool/tests/run_tests.sh
+./custom_components/iopool/run_tests.sh
+```
+
+> ⚠️ **Never create `pytest.ini`** — it breaks async test discovery. All pytest config lives in `pyproject.toml` (`asyncio_mode = "auto"`).
+
+## File Naming
+
+Each integration module has a matching test file:
+
+| Module | Test file |
+|--------|-----------|
+| `sensor.py` | `test_sensor.py` |
+| `binary_sensor.py` | `test_binary_sensor.py` |
+| `select.py` | `test_select.py` |
+| `filtration.py` | `test_filtration.py` |
+| `config_flow.py` | `test_config_flow.py` |
+| `coordinator.py` | `test_coordinator.py` |
+| `__init__.py` | `test_init.py` |
+| `models.py` | `test_models.py` |
+| `api_models.py` | `test_api_models.py` |
+| `diagnostics.py` | `test_diagnostics.py` |
+
+## Test Structure
+
+Group tests by class. Use `class TestIopool{Module}:` naming:
+
+```python
+class TestIopoolSensorPlatform:
+    """Test iopool sensor platform."""
+
+    async def test_async_setup_entry(self, hass, mock_config_entry) -> None:
+        """Test sensor platform setup."""
+        ...
+```
+
+- Tests are **async by default** — `asyncio_mode = "auto"` is active, no `@pytest.mark.asyncio` needed.
+- Group related tests under one class.
+- Name tests clearly: `test_{what}_{condition}` (e.g., `test_temperature_sensor_unavailable`).
+
+## Fixtures
+
+Use fixtures from `conftest.py` and `conftest_hass.py` — do not recreate them:
+
+```python
+# Common fixtures available
+hass              # MagicMock(spec=HomeAssistant)
+mock_config_entry # ConfigEntry mock with runtime_data pre-populated
+coordinator       # IopoolDataUpdateCoordinator mock
+```
+
+When mocking Home Assistant internals, use `MagicMock(spec=ClassName)` to get proper attribute validation:
+
+```python
+from unittest.mock import MagicMock, AsyncMock, patch
+
+hass_mock = MagicMock(spec=HomeAssistant)
+hass_mock.async_add_executor_job = AsyncMock()
+```
+
+## What to Test Per Entity
+
+For each new entity, cover these scenarios:
+
+1. **Setup** — entity is created with the correct `unique_id` and `name`
+2. **Happy path** — `native_value` / `is_on` returns correct data from coordinator
+3. **Extra attributes** — `extra_state_attributes` contains expected keys/values
+4. **Unavailable state** — entity handles `None` / missing coordinator data gracefully
+5. **Restore state** — if entity uses `RestoreEntity`, test last-known state recovery
+
+## Coverage Targets
+
+| Module | Current | Target |
+|--------|---------|--------|
+| `__init__.py` | 100% | ≥ 100% |
+| `coordinator.py` | 100% | ≥ 100% |
+| `sensor.py` | 97% | ≥ 95% |
+| `binary_sensor.py` | 95% | ≥ 95% |
+| `filtration.py` | 51% | improve |
+| All others | — | ≥ 70% |
+
+Run with coverage:
+```bash
+PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ --cov=. --cov-report=term-missing
+```

--- a/.github/skills/add-entity/SKILL.md
+++ b/.github/skills/add-entity/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: add-entity
+description: 'Use when adding a new Home Assistant entity to the iopool integration. Guides through the full workflow: constant, entity description, data mapping, translations (en + fr), entities.mdx documentation, and tests. Use for sensor, binary_sensor, or select platform entities.'
+argument-hint: 'Describe the entity: name, type (sensor/binary_sensor/select), what data it exposes, and where the data comes from in the API response.'
+---
+
+# Add Entity Workflow
+
+Guides the full end-to-end process for adding a new entity to the iopool integration.
+
+## When to Use
+
+- "Add a new sensor for X"
+- "Create a binary sensor that shows Y"
+- "Add a select entity to control Z"
+- Any request to expose new pool data in Home Assistant
+
+## Step-by-Step Procedure
+
+### Step 1 — Clarify the entity
+
+Before writing any code, confirm:
+1. **Platform**: `sensor`, `binary_sensor`, or `select`?
+2. **Data source**: Which field in `IopoolAPIResponse` / `api_models.py` holds the value?
+3. **Display name** (English) and **French translation**
+4. **Availability**: Is data always present, or only under certain conditions?
+
+### Step 2 — Add the constant in `const.py`
+
+```python
+SENSOR_MY_FEATURE = "my_feature"   # ALL_CAPS name, snake_case value
+```
+
+The value becomes the `unique_id` suffix, `translation_key`, and `entity_id` suffix.
+
+### Step 3 — Add the entity description
+
+Choose the template for the correct platform:
+- Sensor → [sensor-template.md](./references/sensor-template.md)
+- Binary sensor → [binary-sensor-template.md](./references/binary-sensor-template.md)
+- Select → [select-template.md](./references/select-template.md)
+
+Add the description to the matching list constant at the top of the platform file.
+
+### Step 4 — Implement the value logic
+
+In the `native_value` property (sensor) or `is_on` property (binary_sensor), add a `case` branch:
+
+```python
+case "my_feature":
+    value = pool.some_object.some_field if pool.some_object else None
+```
+
+For `select`, implement `async_select_option` to handle the user's selection.
+
+### Step 5 — Update translations
+
+Add to **both** `translations/en.json` and `translations/fr.json` under `entity.{platform}`:
+
+```json
+"my_feature": {
+    "name": "My Feature Display Name"
+}
+```
+
+For select entities with fixed options, also add `state` keys:
+```json
+"my_feature": {
+    "name": "My Feature",
+    "state": {
+        "option_key": "Displayed Label"
+    }
+}
+```
+
+### Step 6 — Update `docs/integration/entities.mdx`
+
+Add a row to the entities table:
+
+```mdx
+| My Feature (sensor) | What this entity measures or represents | Always |
+```
+
+Columns: `Name (type)` | Description | Availability
+
+### Step 7 — Write tests
+
+In `tests/test_{platform}.py`, add tests covering:
+1. Entity is created with correct `unique_id` and `entity_id`
+2. `native_value` / `is_on` returns the correct value from coordinator data
+3. `extra_state_attributes` contains expected keys (if applicable)
+4. Entity returns `None` / unavailable when data is missing
+
+### Step 8 — Verify platform loading order
+
+`PLATFORMS` in `__init__.py` must stay:
+```python
+PLATFORMS = [Platform.SENSOR, Platform.SELECT, Platform.BINARY_SENSOR]
+```
+Do not reorder — `binary_sensor` depends on `sensor` being initialized first.
+
+## Completion Checklist
+
+- [ ] Constant added in `const.py`
+- [ ] EntityDescription added to platform list
+- [ ] Value logic implemented in `native_value` / `is_on` / `async_select_option`
+- [ ] `en.json` updated
+- [ ] `fr.json` updated
+- [ ] `docs/integration/entities.mdx` updated
+- [ ] Tests written in `tests/test_{platform}.py`
+- [ ] `PLATFORMS` order unchanged

--- a/.github/skills/add-entity/references/binary-sensor-template.md
+++ b/.github/skills/add-entity/references/binary-sensor-template.md
@@ -1,0 +1,88 @@
+# Binary Sensor Entity Template
+
+## 1. Constant (`const.py`)
+
+```python
+SENSOR_MY_STATUS = "my_status"
+```
+
+## 2. EntityDescription (`binary_sensor.py` — add to `POOL_BINARY_SENSORS` list)
+
+```python
+BinarySensorEntityDescription(
+    key=SENSOR_MY_STATUS,
+    translation_key=SENSOR_MY_STATUS,
+    icon="mdi:icon-name",
+    device_class=BinarySensorDeviceClass.PROBLEM,  # optional
+),
+```
+
+Common `BinarySensorDeviceClass` values:
+- `PROBLEM` — something requires attention (e.g., action required)
+- `RUNNING` — a process is active (e.g., filtration pump)
+- `CONNECTIVITY` — connection state
+
+## 3. Value logic (`is_on` in `IopoolBinarySensor`)
+
+Override the `is_on` property. Add a `case` branch in the `match key:` block, or implement directly:
+
+```python
+@property
+def is_on(self) -> bool | None:
+    """Return true if the binary sensor is on."""
+    pool = self._get_pool()
+    if not pool:
+        return None
+
+    match self.entity_description.key:
+        case "my_status":
+            return bool(pool.some_field)
+        case _:
+            return None
+```
+
+## 4. Filtration-aware sensors
+
+If the sensor depends on the `Filtration` object (like the existing `filtration` sensor), access it via:
+
+```python
+self._filtration: Filtration = coordinator.config_entry.runtime_data.filtration
+```
+
+Then use `self._filtration.is_active` or similar in `is_on`.
+
+## 5. Extra attributes (optional)
+
+```python
+@property
+def extra_state_attributes(self) -> dict[str, Any]:
+    """Return extra state attributes."""
+    pool = self._get_pool()
+    if not pool:
+        return {}
+    return {
+        "some_field": pool.some_field,
+    }
+```
+
+## 6. Translations
+
+`en.json` — under `entity.binary_sensor`:
+```json
+"my_status": {
+    "name": "My Status"
+}
+```
+
+`fr.json` — under `entity.binary_sensor`:
+```json
+"my_status": {
+    "name": "Mon statut"
+}
+```
+
+## 7. `entities.mdx` table row
+
+```mdx
+| My Status (binary sensor) | Description of what triggers the on state | Always |
+```

--- a/.github/skills/add-entity/references/select-template.md
+++ b/.github/skills/add-entity/references/select-template.md
@@ -1,0 +1,97 @@
+# Select Entity Template
+
+## 1. Constant (`const.py`)
+
+```python
+SENSOR_MY_SELECTOR = "my_selector"
+```
+
+## 2. EntityDescription (`select.py` — add to `POOL_SELECTS` list)
+
+```python
+SelectEntityDescription(
+    key=SENSOR_MY_SELECTOR,
+    translation_key=SENSOR_MY_SELECTOR,
+    icon="mdi:icon-name",
+),
+```
+
+## 3. Options list
+
+Define the available options as a constant (list of string values):
+
+```python
+MY_SELECTOR_OPTIONS = ["option_a", "option_b", "option_c"]
+```
+
+Pass options to the entity in `async_setup_entry` or set `_attr_options` in `__init__`:
+
+```python
+self._attr_options = MY_SELECTOR_OPTIONS
+```
+
+## 4. Current value logic
+
+Override `current_option` to return the current selection:
+
+```python
+@property
+def current_option(self) -> str | None:
+    """Return the current selected option."""
+    pool = self._get_pool()
+    if not pool:
+        return None
+    return pool.some_field  # must match one of the options strings
+```
+
+## 5. Selection handler
+
+Override `async_select_option` to act on the user's choice:
+
+```python
+async def async_select_option(self, option: str) -> None:
+    """Handle the user selecting an option."""
+    # e.g., call coordinator or filtration to apply the change
+    await self.coordinator.async_request_refresh()
+```
+
+For boost-style selectors that trigger an API call, fire a HA event:
+
+```python
+self.hass.bus.async_fire(
+    f"{DOMAIN}_{EVENT_MY_ACTION}",
+    {"pool_id": self._pool_id, "option": option},
+)
+```
+
+## 6. Translations
+
+`en.json` — under `entity.select`:
+```json
+"my_selector": {
+    "name": "My Selector",
+    "state": {
+        "option_a": "Option A Label",
+        "option_b": "Option B Label",
+        "option_c": "Option C Label"
+    }
+}
+```
+
+`fr.json` — under `entity.select`:
+```json
+"my_selector": {
+    "name": "Mon sélecteur",
+    "state": {
+        "option_a": "Libellé Option A",
+        "option_b": "Libellé Option B",
+        "option_c": "Libellé Option C"
+    }
+}
+```
+
+## 7. `entities.mdx` table row
+
+```mdx
+| My Selector (select) | Description of what the selector controls | Always |
+```

--- a/.github/skills/add-entity/references/sensor-template.md
+++ b/.github/skills/add-entity/references/sensor-template.md
@@ -1,0 +1,89 @@
+# Sensor Entity Template
+
+## 1. Constant (`const.py`)
+
+```python
+SENSOR_MY_FEATURE = "my_feature"
+```
+
+## 2. EntityDescription (`sensor.py` — add to `POOL_SENSORS` list)
+
+Minimal (no device class):
+```python
+SensorEntityDescription(
+    key=SENSOR_MY_FEATURE,
+    translation_key=SENSOR_MY_FEATURE,
+    icon="mdi:icon-name",
+),
+```
+
+With measurement metadata:
+```python
+SensorEntityDescription(
+    key=SENSOR_MY_FEATURE,
+    translation_key=SENSOR_MY_FEATURE,
+    icon="mdi:icon-name",
+    device_class=SensorDeviceClass.TEMPERATURE,       # optional
+    state_class=SensorStateClass.MEASUREMENT,          # optional
+    suggested_display_precision=1,                     # optional
+    native_unit_of_measurement=UnitOfTemperature.CELSIUS,  # optional
+),
+```
+
+Available `SensorDeviceClass` values relevant to pool monitoring:
+`TEMPERATURE`, `PH` (use `None` for pH — no official HA device class), `VOLTAGE` (for ORP mV)
+
+## 3. Value logic (`native_value` in `IopoolSensor.native_value`)
+
+Add a `case` branch inside the existing `match key:` block:
+
+```python
+case "my_feature":
+    value = pool.latest_measure.my_field if pool.latest_measure else None
+```
+
+Common data paths:
+- `pool.latest_measure.temperature` — water temperature
+- `pool.latest_measure.ph` — pH value
+- `pool.latest_measure.orp` — ORP in mV
+- `pool.advice.filtration_duration` — recommended filtration hours
+- `pool.mode` — current pool mode string
+
+## 4. Extra attributes (optional)
+
+If the entity needs extra state attributes, override `extra_state_attributes`:
+
+```python
+@property
+def extra_state_attributes(self) -> dict[str, Any]:
+    """Return extra state attributes."""
+    pool = self._get_pool()
+    if not pool or not pool.latest_measure:
+        return {}
+    return {
+        "measured_at": pool.latest_measure.measured_at,
+        "is_valid": pool.latest_measure.is_valid,
+    }
+```
+
+## 5. Translations
+
+`en.json` — under `entity.sensor`:
+```json
+"my_feature": {
+    "name": "My Feature"
+}
+```
+
+`fr.json` — under `entity.sensor`:
+```json
+"my_feature": {
+    "name": "Ma fonctionnalité"
+}
+```
+
+## 6. `entities.mdx` table row
+
+```mdx
+| My Feature (sensor) | Description of the measurement | Always |
+```

--- a/.github/workflows/labelers.yml
+++ b/.github/workflows/labelers.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v5
+        uses: crazy-max/ghaction-github-labeler@v6
         with:
           skip-delete: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Download last tested version record
         if: github.event_name == 'schedule' && steps.find-artifact.outputs.result != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           artifact-id: ${{ steps.find-artifact.outputs.result }}
           github-token: ${{ github.token }}
@@ -334,7 +334,7 @@ jobs:
 
       - name: Upload tested version record
         if: github.event_name == 'schedule' && env.SKIP_VERSION_UPLOAD != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: last-tested-${{ matrix.home-assistant-version }}-version
           path: /tmp/last-tested-${{ matrix.home-assistant-version }}.txt
@@ -363,7 +363,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always() && env.SKIP_TESTS != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-py${{ matrix.python-version }}-ha${{ matrix.home-assistant-version }}
           path: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -172,10 +172,9 @@ jobs:
 
       - name: Install Home Assistant Core
         run: |
-          pip install --upgrade pip setuptools wheel
-
           STABLE_VERSION="${{ steps.ha-versions.outputs.stable }}"
           BETA_VERSION="${{ steps.ha-versions.outputs.beta }}"
+          HA_TO_INSTALL=""
 
           echo "🚀 Job: ${{ matrix.home-assistant-version }} on Python ${{ matrix.python-version }}"
           echo "🔧 Trigger: ${{ github.event_name }}"
@@ -210,16 +209,14 @@ jobs:
                 echo "SKIP_REASON=Beta version $BETA_VERSION already tested" >> $GITHUB_ENV
               else
                 echo "✅ New beta version ($BETA_VERSION) → Beta job WILL run"
-                echo "📦 Installing Home Assistant BETA: $BETA_VERSION"
-                pip install homeassistant==$BETA_VERSION
+                HA_TO_INSTALL="$BETA_VERSION"
                 echo "HA_VERSION=$BETA_VERSION" >> $GITHUB_ENV
               fi
 
             elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
               if [[ "${{ inputs.ha_version }}" == "beta" ]]; then
                 echo "🔧 MANUAL trigger + beta selected → Beta job WILL run"
-                echo "📦 Installing Home Assistant BETA: $BETA_VERSION"
-                pip install homeassistant==$BETA_VERSION
+                HA_TO_INSTALL="$BETA_VERSION"
                 echo "HA_VERSION=$BETA_VERSION" >> $GITHUB_ENV
               else
                 echo "🔧 MANUAL trigger + stable selected → Beta job SKIPPED"
@@ -231,8 +228,7 @@ jobs:
               echo "🚀 PUSH/PR trigger → Checking if beta is newer than stable"
               if compare_versions "$BETA_VERSION" "$STABLE_VERSION"; then
                 echo "✅ Beta ($BETA_VERSION) > Stable ($STABLE_VERSION) → Beta job WILL run"
-                echo "📦 Installing Home Assistant BETA: $BETA_VERSION"
-                pip install homeassistant==$BETA_VERSION
+                HA_TO_INSTALL="$BETA_VERSION"
                 echo "HA_VERSION=$BETA_VERSION" >> $GITHUB_ENV
               else
                 echo "⏭️ Beta ($BETA_VERSION) ≤ Stable ($STABLE_VERSION) → Beta job SKIPPED"
@@ -257,16 +253,14 @@ jobs:
                 echo "SKIP_REASON=Stable version $STABLE_VERSION already tested" >> $GITHUB_ENV
               else
                 echo "✅ New stable version ($STABLE_VERSION) → Stable job WILL run"
-                echo "📦 Installing Home Assistant STABLE: $STABLE_VERSION"
-                pip install homeassistant==$STABLE_VERSION
+                HA_TO_INSTALL="$STABLE_VERSION"
                 echo "HA_VERSION=$STABLE_VERSION" >> $GITHUB_ENV
               fi
 
             elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
               if [[ "${{ inputs.ha_version }}" == "stable" ]]; then
                 echo "🔧 MANUAL trigger + stable selected → Stable job WILL run"
-                echo "📦 Installing Home Assistant STABLE: $STABLE_VERSION"
-                pip install homeassistant==$STABLE_VERSION
+                HA_TO_INSTALL="$STABLE_VERSION"
                 echo "HA_VERSION=$STABLE_VERSION" >> $GITHUB_ENV
               else
                 echo "🔧 MANUAL trigger + beta selected → Stable job SKIPPED"
@@ -276,10 +270,17 @@ jobs:
 
             else
               echo "🚀 PUSH/PR trigger → Stable job ALWAYS runs"
-              echo "📦 Installing Home Assistant STABLE: $STABLE_VERSION"
-              pip install homeassistant==$STABLE_VERSION
+              HA_TO_INSTALL="$STABLE_VERSION"
               echo "HA_VERSION=$STABLE_VERSION" >> $GITHUB_ENV
             fi
+          fi
+
+          # Upgrade pip toolchain and install HA only when actually needed
+          if [[ -n "$HA_TO_INSTALL" ]]; then
+            echo "⬆️ Upgrading pip toolchain..."
+            pip install --upgrade pip setuptools wheel
+            echo "📦 Installing Home Assistant: $HA_TO_INSTALL"
+            pip install homeassistant==$HA_TO_INSTALL
           fi
 
       - name: Install test dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -207,6 +207,10 @@ jobs:
                 echo "⏭️ Beta $BETA_VERSION already tested → SKIPPING"
                 echo "SKIP_TESTS=true" >> $GITHUB_ENV
                 echo "SKIP_REASON=Beta version $BETA_VERSION already tested" >> $GITHUB_ENV
+              elif ! compare_versions "$BETA_VERSION" "$STABLE_VERSION"; then
+                echo "⏭️ Beta ($BETA_VERSION) ≤ Stable ($STABLE_VERSION) → obsolete beta, SKIPPING"
+                echo "SKIP_TESTS=true" >> $GITHUB_ENV
+                echo "SKIP_REASON=Beta ($BETA_VERSION) is not newer than stable ($STABLE_VERSION)" >> $GITHUB_ENV
               else
                 echo "✅ New beta version ($BETA_VERSION) → Beta job WILL run"
                 HA_TO_INSTALL="$BETA_VERSION"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,18 +2,16 @@
 name: PyTest
 
 # WORKFLOW LOGIC EXPLANATION:
-# This workflow creates 2 jobs via matrix strategy:
-# 1. Python 3.13 + Home Assistant STABLE (conditionally runs)
-# 2. Python 3.13 + Home Assistant BETA (conditionally runs)
+# This workflow runs two matrix jobs: Python 3.14 + HA STABLE, Python 3.14 + HA BETA.
+# Home Assistant requires Python >= 3.14 (since HA 2026.3.0), so only Python 3.14 is tested.
 #
-# Note: Home Assistant now requires Python >= 3.13.2, so we only test on Python 3.13
+# Execution rules by trigger:
+# - PUSH/PR on dev:  Stable always runs; Beta runs only if newer than stable (semantic versioning).
+# - MANUAL:          Only the selected version (stable or beta) runs, the other is skipped.
+# - SCHEDULE (Mon):  Both jobs run only if a new (untested) version is available.
+#                    Tested versions are tracked via artifacts to avoid redundant executions.
 #
-# Job execution rules:
-# - SCHEDULE (Monday 1AM): Runs beta only if new version available (not already tested)
-# - MANUAL: Runs ONLY the selected version (stable OR beta), skips the other with explanation
-# - PUSH/PR: Both jobs run, but beta only if beta version > stable version (using proper semantic version comparison)
-#
-# Each job shows clear skip/run reasons for transparency
+# Each job clearly logs why it runs or is skipped.
 
 on:
   push:
@@ -37,23 +35,28 @@ on:
           - stable
           - beta
   schedule:
-    # Test beta every Monday at 1:00 AM UTC (3:00 AM Paris time)
+    # Test new HA versions every Monday at 1:00 AM UTC (3:00 AM Paris time)
     - cron: '0 1 * * 1'
+
+# Cancel in-progress runs for the same branch/event to avoid wasting resources.
+# Schedule runs are never cancelled (they are already serialised by cron).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   pyTest:
     name: Run pyTests (${{ matrix.python-version }} - ${{ matrix.home-assistant-version }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false   # Always run both matrix jobs to completion
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
         home-assistant-version: ["stable"]
         include:
-          # Add beta testing job (Python 3.13 only)
-          # This job will be conditionally executed based on trigger type
-          - python-version: "3.13"
+          - python-version: "3.14"
             home-assistant-version: "beta"
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -72,11 +75,39 @@ jobs:
             ${{ runner.os }}-py${{ matrix.python-version }}-hass-${{ matrix.home-assistant-version }}-
             ${{ runner.os }}-py${{ matrix.python-version }}-
 
-      - name: Download last tested beta version
-        if: matrix.home-assistant-version == 'beta' && github.event_name == 'schedule'
-        uses: actions/download-artifact@v7
+      # On scheduled runs, look up the artifact from the most recent previous run
+      # (download-artifact without run-id only searches the current run, so we
+      #  use github-script to find the artifact ID across all runs first).
+      - name: Find last tested version artifact
+        if: github.event_name == 'schedule'
+        id: find-artifact
+        uses: actions/github-script@v7
         with:
-          name: last-tested-beta-version
+          script: |
+            const artifactName = 'last-tested-${{ matrix.home-assistant-version }}-version';
+            const { data } = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: artifactName,
+              per_page: 5,
+            });
+            const artifact = data.artifacts
+              .filter(a => !a.expired)
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+            if (artifact) {
+              core.info(`Found artifact: ${artifact.name} (id: ${artifact.id}, created: ${artifact.created_at})`);
+              return artifact.id.toString();
+            }
+            core.info('No previous artifact found — first scheduled run or artifact has expired');
+            return '';
+          result-encoding: string
+
+      - name: Download last tested version record
+        if: github.event_name == 'schedule' && steps.find-artifact.outputs.result != ''
+        uses: actions/download-artifact@v4
+        with:
+          artifact-id: ${{ steps.find-artifact.outputs.result }}
+          github-token: ${{ github.token }}
           path: /tmp/
         continue-on-error: true
 
@@ -85,97 +116,108 @@ jobs:
           cat > /tmp/compare_versions.py << 'EOF'
           import re
           import sys
-          
+
           def compare_versions(v1, v2):
-              # Extract base version and beta number using regex
+              # Extract base version and optional beta number
               v1_match = re.match(r'(.+?)(?:b(\d+))?$', v1)
               v2_match = re.match(r'(.+?)(?:b(\d+))?$', v2)
-              
+
               v1_base = v1_match.group(1) if v1_match else v1
               v2_base = v2_match.group(1) if v2_match else v2
               v1_beta = int(v1_match.group(2)) if v1_match and v1_match.group(2) else None
               v2_beta = int(v2_match.group(2)) if v2_match and v2_match.group(2) else None
-              
-              # If base versions are different, compare them
+
+              def version_tuple(v):
+                  return tuple(map(int, v.split('.')))
+
               if v1_base != v2_base:
-                  def version_tuple(v):
-                      return tuple(map(int, v.split('.')))
                   return version_tuple(v1_base) > version_tuple(v2_base)
-              
-              # Same base version, check beta status
+
+              # Same base: stable > beta (e.g. 2025.7.0 > 2025.7.0b9)
               if v1_beta is not None and v2_beta is None:
-                  return False  # v1 is beta, v2 is stable -> v1 < v2 (e.g., 2025.7.0b9 < 2025.7.0)
+                  return False
               elif v1_beta is None and v2_beta is not None:
-                  return True   # v1 is stable, v2 is beta -> v1 > v2
+                  return True
               elif v1_beta is not None and v2_beta is not None:
-                  return v1_beta > v2_beta  # Both are beta, compare beta numbers
+                  return v1_beta > v2_beta
               else:
-                  return False  # Both stable and same version -> v1 == v2
-          
+                  return False
+
           if __name__ == "__main__":
               v1, v2 = sys.argv[1], sys.argv[2]
-              result = compare_versions(v1, v2)
-              sys.exit(0 if result else 1)
+              sys.exit(0 if compare_versions(v1, v2) else 1)
           EOF
+
+      # Single PyPI call — outputs both versions for use in subsequent steps.
+      - name: Resolve HA versions from PyPI
+        id: ha-versions
+        run: |
+          echo "🔄 Fetching Home Assistant versions from PyPI..."
+          curl -s "https://pypi.org/pypi/homeassistant/json" > /tmp/ha_pypi.json
+          python3 << 'PYEOF'
+          import json, os
+          with open('/tmp/ha_pypi.json') as f:
+              data = json.load(f)
+          versions = list(data['releases'].keys())
+          stables = [v for v in versions if not any(c in v for c in ['b', 'a', 'rc', 'dev'])]
+          betas = [v for v in versions if 'b' in v]
+          stable = sorted(stables, key=lambda x: tuple(map(int, x.split('.'))), reverse=True)[0] if stables else ''
+          beta = sorted(betas, key=lambda x: tuple(map(int, x.replace('b', '.').replace('.', ' ').split())), reverse=True)[0] if betas else ''
+          print(f'🔍 Latest stable: {stable}')
+          print(f'🧪 Latest beta:   {beta}')
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'stable={stable}\n')
+              f.write(f'beta={beta}\n')
+          PYEOF
 
       - name: Install Home Assistant Core
         run: |
           pip install --upgrade pip setuptools wheel
-          
+
+          STABLE_VERSION="${{ steps.ha-versions.outputs.stable }}"
+          BETA_VERSION="${{ steps.ha-versions.outputs.beta }}"
+
           echo "🚀 Job: ${{ matrix.home-assistant-version }} on Python ${{ matrix.python-version }}"
           echo "🔧 Trigger: ${{ github.event_name }}"
-          
-          # Function to compare versions using our Python script
-          compare_versions() {
-            python3 /tmp/compare_versions.py "$1" "$2"
-          }
-          
-          # LOGIC EXPLANATION:
-          # - STABLE job (Python 3.13): Always runs for all triggers
-          # - BETA job (Python 3.13): Runs conditionally based on trigger:
-          #   * SCHEDULE: Runs beta only if new version available (not already tested)
-          #   * MANUAL: Runs beta only if user selects "beta" 
-          #   * PUSH/PR: Runs beta only if beta version > stable version (using proper semantic version comparison)
-          
+          echo "🔍 Stable: $STABLE_VERSION | 🧪 Beta: $BETA_VERSION"
+
+          compare_versions() { python3 /tmp/compare_versions.py "$1" "$2"; }
+
+          # Guard: stable version must always be resolvable
+          if [[ -z "$STABLE_VERSION" ]]; then
+            echo "❌ Could not resolve stable HA version from PyPI"
+            exit 1
+          fi
+
           if [[ "${{ matrix.home-assistant-version }}" == "beta" ]]; then
             echo "📋 BETA JOB - Checking execution conditions..."
-            
-            if [[ "${{ github.event_name }}" == "schedule" ]]; then
+
+            # Guard: no beta available on PyPI (e.g. right after a stable release)
+            if [[ -z "$BETA_VERSION" ]]; then
+              echo "⚠️ No beta version found on PyPI → Beta job SKIPPED"
+              echo "SKIP_TESTS=true" >> $GITHUB_ENV
+              echo "SKIP_REASON=No beta version available on PyPI" >> $GITHUB_ENV
+
+            elif [[ "${{ github.event_name }}" == "schedule" ]]; then
               echo "📅 SCHEDULE trigger → Checking if new beta version available"
-              
-              # Get current beta version using PyPI API (more reliable than pip index)
-              echo "🔄 Fetching latest beta version from PyPI API..."
-              BETA_VERSION=$(curl -s "https://pypi.org/pypi/homeassistant/json" | python3 -c "import json,sys; data=json.load(sys.stdin); versions=list(data['releases'].keys()); betas=[v for v in versions if 'b' in v]; print(sorted(betas, key=lambda x: tuple(map(int, x.replace('b', '.').replace('.', ' ').split())), reverse=True)[0] if betas else '')")
-              echo "🧪 Current beta version: $BETA_VERSION"
-              
-              # Check last tested version
-              LAST_TESTED_VERSION=""
-              if [[ -f "/tmp/last-tested-beta.txt" ]]; then
-                LAST_TESTED_VERSION=$(cat /tmp/last-tested-beta.txt)
-                echo "📋 Last tested beta version: $LAST_TESTED_VERSION"
-              else
-                echo "📋 No previous beta test record found"
-              fi
-              
-              # Compare versions
-              if [[ -n "$LAST_TESTED_VERSION" && "$BETA_VERSION" == "$LAST_TESTED_VERSION" ]]; then
-                echo "⏭️ Beta version $BETA_VERSION already tested → SKIPPING"
-                echo "💡 Reason: Same beta version ($BETA_VERSION) was already tested in previous scheduled run"
+              LAST_TESTED=""
+              [[ -f "/tmp/last-tested-beta.txt" ]] && LAST_TESTED=$(cat /tmp/last-tested-beta.txt)
+              [[ -n "$LAST_TESTED" ]] && echo "📋 Last tested beta: $LAST_TESTED" || echo "📋 No previous beta test record"
+
+              if [[ -n "$LAST_TESTED" && "$BETA_VERSION" == "$LAST_TESTED" ]]; then
+                echo "⏭️ Beta $BETA_VERSION already tested → SKIPPING"
                 echo "SKIP_TESTS=true" >> $GITHUB_ENV
                 echo "SKIP_REASON=Beta version $BETA_VERSION already tested" >> $GITHUB_ENV
               else
-                echo "✅ New beta version detected ($BETA_VERSION) → Beta job WILL run"
-                SHOULD_TEST_BETA=true
+                echo "✅ New beta version ($BETA_VERSION) → Beta job WILL run"
+                echo "📦 Installing Home Assistant BETA: $BETA_VERSION"
+                pip install homeassistant==$BETA_VERSION
+                echo "HA_VERSION=$BETA_VERSION" >> $GITHUB_ENV
               fi
+
             elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
               if [[ "${{ inputs.ha_version }}" == "beta" ]]; then
                 echo "🔧 MANUAL trigger + beta selected → Beta job WILL run"
-                
-                # Get current beta version using PyPI API for manual trigger too
-                echo "🔄 Fetching latest beta version from PyPI API for manual trigger..."
-                BETA_VERSION=$(curl -s "https://pypi.org/pypi/homeassistant/json" | python3 -c "import json,sys; data=json.load(sys.stdin); versions=list(data['releases'].keys()); betas=[v for v in versions if 'b' in v]; print(sorted(betas, key=lambda x: tuple(map(int, x.replace('b', '.').replace('.', ' ').split())), reverse=True)[0] if betas else '')")
-                echo "🧪 Beta version for manual trigger: $BETA_VERSION"
-                
                 echo "📦 Installing Home Assistant BETA: $BETA_VERSION"
                 pip install homeassistant==$BETA_VERSION
                 echo "HA_VERSION=$BETA_VERSION" >> $GITHUB_ENV
@@ -183,57 +225,59 @@ jobs:
                 echo "🔧 MANUAL trigger + stable selected → Beta job SKIPPED"
                 echo "SKIP_TESTS=true" >> $GITHUB_ENV
                 echo "SKIP_REASON=Manual trigger with stable version selected" >> $GITHUB_ENV
-                echo "⏭️ Skipping Home Assistant installation (job will be skipped)"
               fi
+
             else
-              echo "🚀 PUSH/PR trigger → Checking if beta is newer than stable (using semantic version comparison)"
-              
-              echo "🔄 Fetching versions from PyPI API..."
-              STABLE_VERSION=$(curl -s "https://pypi.org/pypi/homeassistant/json" | python3 -c "import json,sys; data=json.load(sys.stdin); versions=list(data['releases'].keys()); stables=[v for v in versions if 'b' not in v and 'a' not in v and 'rc' not in v and 'dev' not in v]; print(sorted(stables, key=lambda x: tuple(map(int, x.split('.'))), reverse=True)[0] if stables else '')")
-              BETA_VERSION=$(curl -s "https://pypi.org/pypi/homeassistant/json" | python3 -c "import json,sys; data=json.load(sys.stdin); versions=list(data['releases'].keys()); betas=[v for v in versions if 'b' in v]; print(sorted(betas, key=lambda x: tuple(map(int, x.replace('b', '.').replace('.', ' ').split())), reverse=True)[0] if betas else '')")
-              
-              echo "🔍 Stable version: $STABLE_VERSION"
-              echo "🧪 Beta version: $BETA_VERSION"
-              
-              # Use proper semantic version comparison
+              echo "🚀 PUSH/PR trigger → Checking if beta is newer than stable"
               if compare_versions "$BETA_VERSION" "$STABLE_VERSION"; then
                 echo "✅ Beta ($BETA_VERSION) > Stable ($STABLE_VERSION) → Beta job WILL run"
-                echo "💡 Version comparison: Beta is from a newer release line than stable"
                 echo "📦 Installing Home Assistant BETA: $BETA_VERSION"
                 pip install homeassistant==$BETA_VERSION
                 echo "HA_VERSION=$BETA_VERSION" >> $GITHUB_ENV
               else
                 echo "⏭️ Beta ($BETA_VERSION) ≤ Stable ($STABLE_VERSION) → Beta job SKIPPED"
-                echo "💡 Version comparison: Beta versions are considered older than their corresponding stable releases"
-                echo "   Examples: 2025.7.0b9 < 2025.7.0, but 2025.8.0b1 > 2025.7.0"
+                echo "   (e.g. 2025.7.0b9 < 2025.7.0, but 2025.8.0b1 > 2025.7.0)"
                 echo "SKIP_TESTS=true" >> $GITHUB_ENV
-                echo "SKIP_REASON=Beta version ($BETA_VERSION) not newer than stable ($STABLE_VERSION)" >> $GITHUB_ENV
-                echo "⏭️ Skipping Home Assistant installation (job will be skipped)"
+                echo "SKIP_REASON=Beta ($BETA_VERSION) is not newer than stable ($STABLE_VERSION)" >> $GITHUB_ENV
               fi
             fi
-            
+
           else
             echo "📋 STABLE JOB - Checking execution conditions..."
-            
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+
+            if [[ "${{ github.event_name }}" == "schedule" ]]; then
+              echo "📅 SCHEDULE trigger → Checking if new stable version available"
+              LAST_TESTED=""
+              [[ -f "/tmp/last-tested-stable.txt" ]] && LAST_TESTED=$(cat /tmp/last-tested-stable.txt)
+              [[ -n "$LAST_TESTED" ]] && echo "📋 Last tested stable: $LAST_TESTED" || echo "📋 No previous stable test record"
+
+              if [[ -n "$LAST_TESTED" && "$STABLE_VERSION" == "$LAST_TESTED" ]]; then
+                echo "⏭️ Stable $STABLE_VERSION already tested → SKIPPING"
+                echo "SKIP_TESTS=true" >> $GITHUB_ENV
+                echo "SKIP_REASON=Stable version $STABLE_VERSION already tested" >> $GITHUB_ENV
+              else
+                echo "✅ New stable version ($STABLE_VERSION) → Stable job WILL run"
+                echo "📦 Installing Home Assistant STABLE: $STABLE_VERSION"
+                pip install homeassistant==$STABLE_VERSION
+                echo "HA_VERSION=$STABLE_VERSION" >> $GITHUB_ENV
+              fi
+
+            elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
               if [[ "${{ inputs.ha_version }}" == "stable" ]]; then
                 echo "🔧 MANUAL trigger + stable selected → Stable job WILL run"
-                echo "📦 Installing Home Assistant STABLE (latest)"
-                pip install homeassistant
-                STABLE_VERSION=$(pip show homeassistant | grep Version | cut -d' ' -f2)
+                echo "📦 Installing Home Assistant STABLE: $STABLE_VERSION"
+                pip install homeassistant==$STABLE_VERSION
                 echo "HA_VERSION=$STABLE_VERSION" >> $GITHUB_ENV
               else
                 echo "🔧 MANUAL trigger + beta selected → Stable job SKIPPED"
-                echo "💡 Reason: Manual trigger with beta version selected - only beta job will run"
                 echo "SKIP_TESTS=true" >> $GITHUB_ENV
                 echo "SKIP_REASON=Manual trigger with beta version selected" >> $GITHUB_ENV
-                echo "⏭️ Skipping Home Assistant installation (job will be skipped)"
               fi
+
             else
-              echo "🚀 PUSH/PR/SCHEDULE trigger → Stable job ALWAYS runs"
-              echo "📦 Installing Home Assistant STABLE (latest)"
-              pip install homeassistant
-              STABLE_VERSION=$(pip show homeassistant | grep Version | cut -d' ' -f2)
+              echo "🚀 PUSH/PR trigger → Stable job ALWAYS runs"
+              echo "📦 Installing Home Assistant STABLE: $STABLE_VERSION"
+              pip install homeassistant==$STABLE_VERSION
               echo "HA_VERSION=$STABLE_VERSION" >> $GITHUB_ENV
             fi
           fi
@@ -247,20 +291,17 @@ jobs:
       - name: Create Home Assistant test environment
         if: env.SKIP_TESTS != 'true'
         run: |
-          # Create a structure similar to the dev container
           mkdir -p /tmp/hass-config
           cp -r ${{ github.workspace }}/custom_components /tmp/hass-config/
 
-      - name: Run tests using existing script
+      - name: Run tests
         if: env.SKIP_TESTS != 'true'
         run: |
           echo "🧪 Running tests with Home Assistant ${{ env.HA_VERSION }} on Python ${{ matrix.python-version }}"
-          # Adapt the existing run_tests.sh script for GitHub Actions
           cd /tmp/hass-config
           PYTHONPATH=/tmp/hass-config python -m pytest \
             custom_components/iopool/tests/ \
             --cov=custom_components/iopool \
-            --cov-config=custom_components/iopool/.coveragerc \
             --cov-report=xml \
             --cov-report=term-missing \
             --html=test-report.html \
@@ -273,19 +314,32 @@ jobs:
             --durations=10 \
             --asyncio-mode=auto
 
-      - name: Save tested beta version
-        if: matrix.home-assistant-version == 'beta' && env.SKIP_TESTS != 'true' && github.event_name == 'schedule'
+      # Save the tested version to an artifact so the next scheduled run can compare.
+      # If tests were skipped (same version), re-upload the existing record to refresh
+      # artifact retention (9 days > 7-day cron interval) and avoid repeated re-testing
+      # after the artifact would otherwise expire.
+      - name: Save tested version record
+        if: github.event_name == 'schedule'
         run: |
-          echo "💾 Saving tested beta version: ${{ env.HA_VERSION }}"
-          echo "${{ env.HA_VERSION }}" > /tmp/last-tested-beta.txt
+          ARTIFACT_FILE="/tmp/last-tested-${{ matrix.home-assistant-version }}.txt"
+          if [[ "${{ env.SKIP_TESTS }}" != "true" && -n "${{ env.HA_VERSION }}" ]]; then
+            echo "💾 Saving tested version: ${{ env.HA_VERSION }}"
+            echo "${{ env.HA_VERSION }}" > "$ARTIFACT_FILE"
+          elif [[ -f "$ARTIFACT_FILE" ]]; then
+            echo "♻️ Refreshing artifact retention (version unchanged): $(cat $ARTIFACT_FILE)"
+          else
+            echo "⚠️ No version to track and no previous record — skipping artifact upload"
+            echo "SKIP_VERSION_UPLOAD=true" >> $GITHUB_ENV
+          fi
 
-      - name: Upload tested beta version record
-        if: matrix.home-assistant-version == 'beta' && env.SKIP_TESTS != 'true' && github.event_name == 'schedule'
-        uses: actions/upload-artifact@v6
+      - name: Upload tested version record
+        if: github.event_name == 'schedule' && env.SKIP_VERSION_UPLOAD != 'true'
+        uses: actions/upload-artifact@v4
         with:
-          name: last-tested-beta-version
-          path: /tmp/last-tested-beta.txt
-          retention-days: 30
+          name: last-tested-${{ matrix.home-assistant-version }}-version
+          path: /tmp/last-tested-${{ matrix.home-assistant-version }}.txt
+          retention-days: 9
+          overwrite: true
 
       - name: Upload coverage to Codecov
         if: matrix.home-assistant-version == 'stable' && env.SKIP_TESTS != 'true'
@@ -299,15 +353,17 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && env.SKIP_TESTS != 'true' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/hass-config/junit.xml
           flags: unittests
+          report_type: test_results
+          fail_ci_if_error: false
 
-      - name: Upload test results
+      - name: Upload test artifacts
         if: always() && env.SKIP_TESTS != 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-py${{ matrix.python-version }}-ha${{ matrix.home-assistant-version }}
           path: |
@@ -315,131 +371,51 @@ jobs:
             /tmp/hass-config/junit.xml
             /tmp/hass-config/test-report.html
 
-      - name: Beta test summary
-        if: matrix.home-assistant-version == 'beta'
-        run: |
-          if [[ "${{ env.SKIP_TESTS }}" == "true" ]]; then
-            echo "🔄 Beta test was SKIPPED: ${{ env.SKIP_REASON }}"
-          else
-            echo "🎉 Beta test COMPLETED successfully with Home Assistant ${{ env.HA_VERSION }}"
-            if [[ "${{ github.event_name }}" == "schedule" ]]; then
-              echo "📝 Beta version ${{ env.HA_VERSION }} has been saved for future comparison"
-            fi
-          fi
-
-      - name: Stable test summary
-        if: matrix.home-assistant-version == 'stable'
-        run: |
-          if [[ "${{ env.SKIP_TESTS }}" == "true" ]]; then
-            echo "🔄 Stable test was SKIPPED: ${{ env.SKIP_REASON }}"
-          else
-            echo "🎉 Stable test COMPLETED successfully with Home Assistant ${{ env.HA_VERSION }}"
-          fi
-
   tests-summary:
     name: Tests Summary
     if: always()
     needs: [pyTest]
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Check test results
         run: |
-          echo "📊 Test Results Summary:"
-          echo "Tests: ${{ needs.pyTest.result }}"
+          echo "📊 Test Results Summary"
+          echo "Overall result: ${{ needs.pyTest.result }}"
+          echo "Trigger:        ${{ github.event_name }}"
           echo ""
-          
-          # Extract outputs from the matrix jobs
-          echo "🔍 Job Details:"
-          
-          # Get actual versions from PyPI to display in summary
-          echo "🔄 Fetching current versions from PyPI..."
-          CURRENT_STABLE_VERSION=$(curl -s "https://pypi.org/pypi/homeassistant/json" | python3 -c "import json,sys; data=json.load(sys.stdin); versions=list(data['releases'].keys()); stables=[v for v in versions if 'b' not in v and 'a' not in v and 'rc' not in v and 'dev' not in v]; print(sorted(stables, key=lambda x: tuple(map(int, x.split('.'))), reverse=True)[0] if stables else '')")
-          CURRENT_BETA_VERSION=$(curl -s "https://pypi.org/pypi/homeassistant/json" | python3 -c "import json,sys; data=json.load(sys.stdin); versions=list(data['releases'].keys()); betas=[v for v in versions if 'b' in v]; print(sorted(betas, key=lambda x: tuple(map(int, x.replace('b', '.').replace('.', ' ').split())), reverse=True)[0] if betas else '')")
-          
-          echo "🔍 Current stable version: $CURRENT_STABLE_VERSION"
-          echo "🧪 Current beta version: $CURRENT_BETA_VERSION"
+
+          curl -s "https://pypi.org/pypi/homeassistant/json" > /tmp/ha_pypi.json
+          python3 << 'PYEOF'
+          import json
+          with open('/tmp/ha_pypi.json') as f:
+              data = json.load(f)
+          versions = list(data['releases'].keys())
+          stables = [v for v in versions if not any(c in v for c in ['b', 'a', 'rc', 'dev'])]
+          betas = [v for v in versions if 'b' in v]
+          stable = sorted(stables, key=lambda x: tuple(map(int, x.split('.'))), reverse=True)[0] if stables else 'N/A'
+          beta = sorted(betas, key=lambda x: tuple(map(int, x.replace('b', '.').replace('.', ' ').split())), reverse=True)[0] if betas else 'N/A'
+          print(f'Latest stable: {stable}')
+          print(f'Latest beta:   {beta}')
+          PYEOF
+
           echo ""
-          
-          # Parse the job results to extract version information
-          STABLE_RESULT=""
-          BETA_RESULT=""
-          STABLE_VERSION="$CURRENT_STABLE_VERSION"
-          BETA_VERSION="$CURRENT_BETA_VERSION"
-          STABLE_SKIP_REASON=""
-          BETA_SKIP_REASON=""
-          
-          # Note: GitHub Actions doesn't provide direct access to job outputs in matrix jobs
-          # So we'll reconstruct the information based on trigger type and inputs
-          
-          TRIGGER="${{ github.event_name }}"
-          
-          echo "🔧 Trigger: $TRIGGER"
-          
-          if [[ "$TRIGGER" == "workflow_dispatch" ]]; then
-            SELECTED_VERSION="${{ inputs.ha_version }}"
-            echo "🎯 Selected version: $SELECTED_VERSION"
-            
-            if [[ "$SELECTED_VERSION" == "stable" ]]; then
-              STABLE_RESULT="✅ EXECUTED"
-              BETA_RESULT="⏭️ SKIPPED"
-              BETA_SKIP_REASON="Manual trigger with stable version selected"
-            else
-              STABLE_RESULT="⏭️ SKIPPED"
-              BETA_RESULT="✅ EXECUTED"
-              STABLE_SKIP_REASON="Manual trigger with beta version selected"
-            fi
-          elif [[ "$TRIGGER" == "schedule" ]]; then
-            STABLE_RESULT="✅ EXECUTED"
-            BETA_RESULT="🔄 CONDITIONAL"
-            echo "📅 Schedule trigger: Stable always runs, Beta runs only if new version available"
-          else
-            STABLE_RESULT="✅ EXECUTED"
-            BETA_RESULT="🔄 CONDITIONAL"
-            echo "🚀 Push/PR trigger: Stable always runs, Beta runs only if newer than stable"
-          fi
-          
-          echo ""
-          echo "📋 Job Execution Summary:"
           echo "┌─────────────────────────────────────────────────────────────┐"
-          echo "│                     STABLE JOB                              │"
+          echo "│ Trigger: ${{ github.event_name }}"
           echo "├─────────────────────────────────────────────────────────────┤"
-          echo "│ Status: $STABLE_RESULT"
-          if [[ -n "$STABLE_SKIP_REASON" ]]; then
-            echo "│ Skip Reason: $STABLE_SKIP_REASON"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "│ • ${{ inputs.ha_version }} job → ✅ EXECUTED"
+            echo "│ • other job     → ⏭️ SKIPPED (manual: only selected version runs)"
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "│ • stable job → 🔄 CONDITIONAL (skipped if already tested)"
+            echo "│ • beta job   → 🔄 CONDITIONAL (skipped if already tested)"
           else
-            echo "│ Version: $STABLE_VERSION (stable)"
-          fi
-          echo "├─────────────────────────────────────────────────────────────┤"
-          echo "│                      BETA JOB                               │"
-          echo "├─────────────────────────────────────────────────────────────┤"
-          echo "│ Status: $BETA_RESULT"
-          if [[ -n "$BETA_SKIP_REASON" ]]; then
-            echo "│ Skip Reason: $BETA_SKIP_REASON"
-          else
-            echo "│ Version: $BETA_VERSION (beta)"
+            echo "│ • stable job → ✅ ALWAYS executed (regression testing)"
+            echo "│ • beta job   → 🔄 CONDITIONAL (only if newer than stable)"
           fi
           echo "└─────────────────────────────────────────────────────────────┘"
           echo ""
-          
-          # Additional context based on trigger type
-          if [[ "$TRIGGER" == "workflow_dispatch" ]]; then
-            echo "💡 Manual Execution Notes:"
-            echo "   • Only the selected version (${{ inputs.ha_version }}) was executed"
-            echo "   • The other job was skipped to save resources"
-          elif [[ "$TRIGGER" == "schedule" ]]; then
-            echo "💡 Scheduled Execution Notes:"
-            echo "   • Stable version always runs to ensure compatibility"
-            echo "   • Beta runs only if a new beta version is available"
-            echo "   • Beta versions are tracked to avoid duplicate testing"
-          else
-            echo "💡 Push/PR Execution Notes:"
-            echo "   • Stable version always runs for regression testing"
-            echo "   • Beta runs only if it's from a newer release line than stable"
-            echo "   • Uses semantic versioning: 2025.7.0b9 < 2025.7.0, but 2025.8.0b1 > 2025.7.0"
-          fi
-          
-          echo ""
+
           if [[ "${{ needs.pyTest.result }}" == "success" ]]; then
             echo "✅ All executed tests passed!"
             exit 0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -405,12 +405,17 @@ jobs:
           PYEOF
 
           echo ""
-          echo "┌─────────────────────────────────────────────────────────────┐"
+          echo "┌──────────────────────────────────────────────────────────────────────┐"
           echo "│ Trigger: ${{ github.event_name }}"
-          echo "├─────────────────────────────────────────────────────────────┤"
+          echo "├──────────────────────────────────────────────────────────────────────┤"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ inputs.ha_version }}" == "stable" ]]; then
+              OTHER_JOB="beta"
+            else
+              OTHER_JOB="stable"
+            fi
             echo "│ • ${{ inputs.ha_version }} job → ✅ EXECUTED"
-            echo "│ • other job     → ⏭️ SKIPPED (manual: only selected version runs)"
+            echo "│ • $OTHER_JOB job    → ⏭️ SKIPPED (manual: only selected version runs)"
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "│ • stable job → 🔄 CONDITIONAL (skipped if already tested)"
             echo "│ • beta job   → 🔄 CONDITIONAL (skipped if already tested)"
@@ -418,7 +423,7 @@ jobs:
             echo "│ • stable job → ✅ ALWAYS executed (regression testing)"
             echo "│ • beta job   → 🔄 CONDITIONAL (only if newer than stable)"
           fi
-          echo "└─────────────────────────────────────────────────────────────┘"
+          echo "└──────────────────────────────────────────────────────────────────────┘"
           echo ""
 
           if [[ "${{ needs.pyTest.result }}" == "success" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.2-beta.1](https://github.com/mguyard/hass-iopool/compare/v1.2.1...v1.2.2-beta.1) (2026-03-14)
+
+
+### Bug Fixes
+
+* **ci:** 🐛 Skip beta on schedule when beta <= stable ([711cd45](https://github.com/mguyard/hass-iopool/commit/711cd45641f35ddb69ae4daa0445ed234853aece))
+
 ## [1.2.1-beta.2](https://github.com/mguyard/hass-iopool/compare/v1.2.1-beta.1...v1.2.1-beta.2) (2026-03-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@
 
 * **ci:** 🐛 Skip beta on schedule when beta <= stable ([711cd45](https://github.com/mguyard/hass-iopool/commit/711cd45641f35ddb69ae4daa0445ed234853aece))
 
-## [1.2.1-beta.2](https://github.com/mguyard/hass-iopool/compare/v1.2.1-beta.1...v1.2.1-beta.2) (2026-03-14)
-
-
-### Bug Fixes
-
-* **ci:** 🐛 Skip beta on schedule when beta <= stable ([711cd45](https://github.com/mguyard/hass-iopool/commit/711cd45641f35ddb69ae4daa0445ed234853aece))
-
 ## [1.2.1](https://github.com/mguyard/hass-iopool/compare/v1.2.0...v1.2.1) (2026-02-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.1-beta.2](https://github.com/mguyard/hass-iopool/compare/v1.2.1-beta.1...v1.2.1-beta.2) (2026-03-14)
+
+
+### Bug Fixes
+
+* **ci:** 🐛 Skip beta on schedule when beta <= stable ([711cd45](https://github.com/mguyard/hass-iopool/commit/711cd45641f35ddb69ae4daa0445ed234853aece))
+
 ## [1.2.1-beta.1](https://github.com/mguyard/hass-iopool/compare/v1.2.0...v1.2.1-beta.1) (2025-10-25)
 
 

--- a/custom_components/iopool/manifest.json
+++ b/custom_components/iopool/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/mguyard/hass-iopool/issues",
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "1.2.1-beta.1"
+  "version": "1.2.1-beta.2"
 }

--- a/custom_components/iopool/manifest.json
+++ b/custom_components/iopool/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/mguyard/hass-iopool/issues",
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "1.2.1-beta.2"
+  "version": "1.2.2-beta.1"
 }


### PR DESCRIPTION
## Summary

Release `1.2.1` — full rewrite and refinements of the GitHub Actions test workflow, addition of GitHub Copilot customization files, and a Dependabot action bump.

---

## Commits

- **[`d598ae0`](https://github.com/mguyard/hass-iopool/commit/d598ae00da0c8830df41f80774d434898673940c)** — `chore(deps): bump crazy-max/ghaction-github-labeler from 5 to 6`
  Dependabot bump for the GitHub labeler action.

- **[`86fedcd`](https://github.com/mguyard/hass-iopool/commit/86fedcd9003a64aadcac811320452c467fc217d4)** — `chore(copilot): 🔧 Add Copilot instructions, skills, and init`
  Adds GitHub Copilot customization files (instructions, skills, `copilot-instructions.md`) to improve AI-assisted development within this repository.

- **[`67a02fd`](https://github.com/mguyard/hass-iopool/commit/67a02fd1c866ca6e7b749874908e164fd12b5b55)** — `chore(ci): 🔧 Rewrite tests workflow with improvements`
  Complete rewrite of `tests.yaml`: concurrency control, `fail-fast: false`, single PyPI call, cross-run artifact tracking for stable/beta versions, `retention-days: 9` (outlasts weekly cron), updated action versions (codecov@v5, upload@v7, download@v8), and proper skip guards per trigger type.

- **[`198fdaf`](https://github.com/mguyard/hass-iopool/commit/198fdaff257604d450c6e451681bac32f6bd5f72)** — `chore(deps): 🔧 Bump upload-artifact to v7, download-artifact to v8`
  Updates artifact actions to their latest major versions (manually applied from Dependabot PRs #46 and #47).

- **[`59a6891`](https://github.com/mguyard/hass-iopool/commit/59a6891be59900d1717fc7fec1e8a15163704e2e)** — `refactor(ci): ♻️ Skip pip upgrade when HA install not needed`
  Defers `pip install --upgrade pip setuptools wheel` and HA installation using an `HA_TO_INSTALL` variable — no pip overhead on skipped jobs.

- **[`711cd45`](https://github.com/mguyard/hass-iopool/commit/711cd45641f35ddb69ae4daa0445ed234853aece)** — `fix(ci): 🐛 Skip beta on schedule when beta <= stable`
  On schedule trigger, the beta job now checks that beta > stable before running — mirrors the push/PR behaviour and avoids testing obsolete beta versions (e.g. `2026.3.0b4` already superseded by `2026.3.1`).

- **[`131a787`](https://github.com/mguyard/hass-iopool/commit/131a78788945de3c57e21ae14b5e66e6c6a89f73)** — `refactor(ci): ♻️ Fix dynamic job name in summary output`
  Replaces the hardcoded `other job` label in the `tests-summary` step with dynamic computation: if selected job is `stable`, the skipped label shows `beta`, and vice versa.