### PR TITLE
fix(sensor): 🐛 Fix `elapsed_filtration_duration` on HA 2026.3

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -7,15 +7,56 @@ applyTo: "custom_components/iopool/tests/**/*.py"
 
 ## Environment
 
-Tests **require** a Home Assistant dev container. Always set `PYTHONPATH`:
+Tests **require** a Home Assistant dev container. Before running tests, detect the execution environment automatically.
+
+### Step 1 — Detect if running inside the devcontainer
+
+Check for the presence of the `/workspaces` directory:
 
 ```bash
-# From /workspaces/home-assistant-dev/config
+test -d /workspaces && echo "inside devcontainer" || echo "outside devcontainer"
+```
+
+**If inside the devcontainer**, run pytest directly:
+
+```bash
+cd /workspaces/home-assistant-dev/config
 PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/
 
 # Or use the shortcut scripts (auto-configure PYTHONPATH)
 ./custom_components/iopool/tests/run_tests.sh
 ./custom_components/iopool/run_tests.sh
+```
+
+### Step 2 — If NOT inside the devcontainer
+
+List running Docker containers and present the result:
+
+```bash
+docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Names}}"
+```
+
+- If containers are listed, identify the HA devcontainer and use its ID in Step 3.
+- If no container is running, inform the developer: *"No running container found. Please start the HA devcontainer first."*
+
+> ⚠️ The container ID changes every time the devcontainer is restarted. Always retrieve it fresh via `docker ps`.
+
+### Step 3 — Run tests via Docker exec
+
+```bash
+docker exec -w /workspaces/home-assistant-dev/config \
+  <CONTAINER_ID> \
+  bash -c "PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ -v --tb=short"
+```
+
+Replace `<CONTAINER_ID>` with the value obtained from `docker ps`.
+
+To run with coverage:
+
+```bash
+docker exec -w /workspaces/home-assistant-dev/config \
+  <CONTAINER_ID> \
+  bash -c "PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ --cov=. --cov-report=term-missing"
 ```
 
 > ⚠️ **Never create `pytest.ini`** — it breaks async test discovery. All pytest config lives in `pyproject.toml` (`asyncio_mode = "auto"`).
@@ -95,7 +136,4 @@ For each new entity, cover these scenarios:
 | `filtration.py` | 51% | improve |
 | All others | — | ≥ 70% |
 
-Run with coverage:
-```bash
-PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ --cov=. --cov-report=term-missing
-```
+See the **Environment** section above for the appropriate coverage command depending on whether you are inside or outside the devcontainer.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 	<img src="https://img.shields.io/github/last-commit/mguyard/hass-iopool?style=default&color=0080ff" alt="Last Commit">
 	<img src="https://img.shields.io/github/languages/top/mguyard/hass-iopool?style=default&color=0080ff" alt="repo-top-language">
 	<img src="https://img.shields.io/github/languages/count/mguyard/hass-iopool?style=default&color=0080ff" alt="repo-language-count">
-    <img src="https://codecov.io/github/mguyard/hass-iopool/graph/badge.svg?token=N2Y1LAEBGG" alt="codecov">
+    <a href="https://codecov.io/gh/mguyard/hass-iopool" >
+        <img src="https://codecov.io/gh/mguyard/hass-iopool/graph/badge.svg?token=N2Y1LAEBGG" alt="CodeCov"/>
+    </a>
 <p>
 <p align="center">
     <img src="https://img.shields.io/github/v/release/mguyard/hass-iopool?label=Stable" alt="Last Stable Release">

--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -177,6 +177,7 @@ async def async_setup_entry(
                 name=friendly_name,
                 unique_id=f"{entry.entry_id}_{pool_id}_{SENSOR_ELAPSED_FILTRATION}",
                 source_entity_id=f"sensor.iopool_{pool.title.lower().replace(' ', '_')}_{SENSOR_TEMPERATURE}",
+                state_class=SensorStateClass.MEASUREMENT,
             )
             history_stats_entity.entity_id = f"sensor.iopool_{pool.title.lower().replace(' ', '_')}_{SENSOR_ELAPSED_FILTRATION}"
             # Add the entity to Home Assistant

--- a/custom_components/iopool/tests/test_sensor.py
+++ b/custom_components/iopool/tests/test_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.iopool.const import DOMAIN
 from custom_components.iopool.sensor import (
@@ -323,7 +323,7 @@ class TestAsyncSetupEntryEdgeCases:
         mock_history_stats.return_value = MagicMock()
 
         mock_history_coordinator = MagicMock()
-        mock_history_coordinator.async_config_entry_first_refresh = MagicMock(
+        mock_history_coordinator.async_config_entry_first_refresh = AsyncMock(
             return_value=None
         )
         mock_coordinator_class.return_value = mock_history_coordinator
@@ -339,8 +339,11 @@ class TestAsyncSetupEntryEdgeCases:
         mock_template.assert_called()
         mock_history_stats.assert_called_once()
         mock_coordinator_class.assert_called_once()
-        # Note: HistoryStatsSensor is called but within a try/except that might fail
-        # So we just verify that basic entities were added
+        # Verify HistoryStatsSensor was called with state_class=MEASUREMENT (required since HA 2026.3)
+        mock_sensor_class.assert_called_once()
+        call_kwargs = mock_sensor_class.call_args[1]
+        from homeassistant.components.sensor import SensorStateClass
+        assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
         assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio
@@ -400,7 +403,9 @@ class TestAsyncSetupEntryEdgeCases:
         mock_history_stats.return_value = MagicMock()
 
         mock_history_coordinator = MagicMock()
-        mock_history_coordinator.async_config_entry_first_refresh = MagicMock()
+        mock_history_coordinator.async_config_entry_first_refresh = AsyncMock(
+            return_value=None
+        )
         mock_coordinator_class.return_value = mock_history_coordinator
 
         mock_history_sensor = MagicMock()
@@ -411,11 +416,16 @@ class TestAsyncSetupEntryEdgeCases:
         await async_setup_entry(hass, config_entry, mock_async_add_entities)
 
         # Verify French language template was used
-        # This is indirectly tested by checking that the coordinator was created
         mock_coordinator_class.assert_called_once()
         call_args = mock_coordinator_class.call_args[0]
         friendly_name = call_args[3]  # 4th argument is friendly_name
         assert friendly_name == "Piscine Test Durée de filtration écoulée aujourd'hui"
+        # Verify HistoryStatsSensor was called with state_class=MEASUREMENT (required since HA 2026.3)
+        mock_sensor_class.assert_called_once()
+        call_kwargs = mock_sensor_class.call_args[1]
+        from homeassistant.components.sensor import SensorStateClass
+        assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
+        assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio
     @patch("homeassistant.helpers.template.Template")

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "iopool",
     "country": "FR",
-    "homeassistant": "2025.2.0"
+    "homeassistant": "2026.3.0"
 }


### PR DESCRIPTION
## Summary

Fix the `elapsed_filtration_duration` sensor becoming unavailable after updating to Home Assistant 2026.3.

The HA PR [home-assistant/core#148637](https://github.com/home-assistant/core/pull/148637) introduced a breaking change in `HistoryStatsSensor.__init__()`: `state_class` became a **mandatory keyword-only parameter** (no default). Omitting it raises a `TypeError` silently caught by the `except (ValueError, KeyError, TypeError)` block, preventing sensor creation without any visible error.

Closes #51

---

## Commits

- **fix(sensor)**: Add required `state_class` to `HistoryStatsSensor`  
  https://github.com/mguyard/hass-iopool/commit/b3a7b8c  
  Adds `state_class=SensorStateClass.MEASUREMENT` to the `HistoryStatsSensor(...)` call, fixing the `TypeError` introduced in HA 2026.3.

- **chore(deps)**: Bump minimum HA version to `2026.3.0`  
  https://github.com/mguyard/hass-iopool/commit/1de10df  
  Updates `hacs.json` to require HA ≥ 2026.3.0, since `state_class` as a constructor parameter is only available from that version.

- **test(sensor)**: Fix mocks and assert `state_class` on `HistoryStatsSensor`  
  https://github.com/mguyard/hass-iopool/commit/6d6634c  
  Replaces `MagicMock` with `AsyncMock` for `async_config_entry_first_refresh` (sync mock was causing a `TypeError` caught silently, leaving `HistoryStatsSensor` never reached). Adds `assert_called_once()` and `state_class` assertions in both EN and FR test variants.