### PR TITLE
fix(sensor): 🐛 Fix `HistoryStats` incompatibility with HA 2026.4

### DIFF
--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -158,6 +158,7 @@ async def async_setup_entry(
             start=start_template,
             end=end_template,
             duration=None,
+            min_state_duration=timedelta(0),
         )
         # Create the coordinator
         coordinator = HistoryStatsUpdateCoordinator(

--- a/custom_components/iopool/tests/test_sensor.py
+++ b/custom_components/iopool/tests/test_sensor.py
@@ -344,6 +344,10 @@ class TestAsyncSetupEntryEdgeCases:
         call_kwargs = mock_sensor_class.call_args[1]
         from homeassistant.components.sensor import SensorStateClass
         assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
+        # Verify HistoryStats was called with min_state_duration=timedelta(0) (required since HA 2026.4)
+        from datetime import timedelta
+        hs_call_kwargs = mock_history_stats.call_args[1]
+        assert hs_call_kwargs.get("min_state_duration") == timedelta(0)
         assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio
@@ -425,6 +429,10 @@ class TestAsyncSetupEntryEdgeCases:
         call_kwargs = mock_sensor_class.call_args[1]
         from homeassistant.components.sensor import SensorStateClass
         assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
+        # Verify HistoryStats was called with min_state_duration=timedelta(0) (required since HA 2026.4)
+        from datetime import timedelta
+        hs_call_kwargs = mock_history_stats.call_args[1]
+        assert hs_call_kwargs.get("min_state_duration") == timedelta(0)
         assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "iopool",
     "country": "FR",
-    "homeassistant": "2026.3.0"
+    "homeassistant": "2026.4.0"
 }


### PR DESCRIPTION
## Summary

Fixes the `TypeError: HistoryStats.__init__() missing 1 required positional argument: 'min_state_duration'` introduced in Home Assistant 2026.4 (HA PR [#151643](https://github.com/home-assistant/core/pull/151643)).

The `HistoryStats.__init__()` constructor now requires a `min_state_duration: datetime.timedelta` argument. This PR passes `timedelta(0)` (equivalent to `DEFAULT_MIN_STATE_DURATION`) to preserve existing behavior — all on-periods are counted with no minimum filter.

Closes #53

## Commits

- **`fix(sensor)`** — [`85883a0`](https://github.com/mguyard/hass-iopool/commit/85883a0) Add required `min_state_duration` argument to `HistoryStats.__init__()` call. Passes `timedelta(0)` to preserve existing behavior.
- **`chore(deps)`** — [`3edc4d5`](https://github.com/mguyard/hass-iopool/commit/3edc4d5) Bump minimum required Home Assistant version to `2026.4.0` in `hacs.json`.
- **`test(sensor)`** — [`8c17c53`](https://github.com/mguyard/hass-iopool/commit/8c17c53) Add assertion in both EN and FR test variants to verify `HistoryStats` is called with `min_state_duration=timedelta(0)`.