### PR TITLE
chore(release): 🔧 Release 1.2.3 — Fix HistoryStatsSensor compatibility with HA 2026.3

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -7,15 +7,56 @@ applyTo: "custom_components/iopool/tests/**/*.py"
 
 ## Environment
 
-Tests **require** a Home Assistant dev container. Always set `PYTHONPATH`:
+Tests **require** a Home Assistant dev container. Before running tests, detect the execution environment automatically.
+
+### Step 1 — Detect if running inside the devcontainer
+
+Check for the presence of the `/workspaces` directory:
 
 ```bash
-# From /workspaces/home-assistant-dev/config
+test -d /workspaces && echo "inside devcontainer" || echo "outside devcontainer"
+```
+
+**If inside the devcontainer**, run pytest directly:
+
+```bash
+cd /workspaces/home-assistant-dev/config
 PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/
 
 # Or use the shortcut scripts (auto-configure PYTHONPATH)
 ./custom_components/iopool/tests/run_tests.sh
 ./custom_components/iopool/run_tests.sh
+```
+
+### Step 2 — If NOT inside the devcontainer
+
+List running Docker containers and present the result:
+
+```bash
+docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Names}}"
+```
+
+- If containers are listed, identify the HA devcontainer and use its ID in Step 3.
+- If no container is running, inform the developer: *"No running container found. Please start the HA devcontainer first."*
+
+> ⚠️ The container ID changes every time the devcontainer is restarted. Always retrieve it fresh via `docker ps`.
+
+### Step 3 — Run tests via Docker exec
+
+```bash
+docker exec -w /workspaces/home-assistant-dev/config \
+  <CONTAINER_ID> \
+  bash -c "PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ -v --tb=short"
+```
+
+Replace `<CONTAINER_ID>` with the value obtained from `docker ps`.
+
+To run with coverage:
+
+```bash
+docker exec -w /workspaces/home-assistant-dev/config \
+  <CONTAINER_ID> \
+  bash -c "PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ --cov=. --cov-report=term-missing"
 ```
 
 > ⚠️ **Never create `pytest.ini`** — it breaks async test discovery. All pytest config lives in `pyproject.toml` (`asyncio_mode = "auto"`).
@@ -95,7 +136,4 @@ For each new entity, cover these scenarios:
 | `filtration.py` | 51% | improve |
 | All others | — | ≥ 70% |
 
-Run with coverage:
-```bash
-PYTHONPATH=/workspaces/home-assistant-dev python -m pytest custom_components/iopool/tests/ --cov=. --cov-report=term-missing
-```
+See the **Environment** section above for the appropriate coverage command depending on whether you are inside or outside the devcontainer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.3-beta.1](https://github.com/mguyard/hass-iopool/compare/v1.2.2...v1.2.3-beta.1) (2026-03-15)
+
+
+### Bug Fixes
+
+* **sensor:** 🐛 Add required `state_class` to `HistoryStatsSensor` ([b3a7b8c](https://github.com/mguyard/hass-iopool/commit/b3a7b8ccc9fe010ac296e88ddab657ddadaaaa14)), closes [home-assistant/core#148637](https://github.com/home-assistant/core/issues/148637) [#51](https://github.com/mguyard/hass-iopool/issues/51)
+
 ## [1.2.2](https://github.com/mguyard/hass-iopool/compare/v1.2.1...v1.2.2) (2026-03-14)
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 	<img src="https://img.shields.io/github/last-commit/mguyard/hass-iopool?style=default&color=0080ff" alt="Last Commit">
 	<img src="https://img.shields.io/github/languages/top/mguyard/hass-iopool?style=default&color=0080ff" alt="repo-top-language">
 	<img src="https://img.shields.io/github/languages/count/mguyard/hass-iopool?style=default&color=0080ff" alt="repo-language-count">
-    <img src="https://codecov.io/github/mguyard/hass-iopool/graph/badge.svg?token=N2Y1LAEBGG" alt="codecov">
+    <a href="https://codecov.io/gh/mguyard/hass-iopool" >
+        <img src="https://codecov.io/gh/mguyard/hass-iopool/graph/badge.svg?token=N2Y1LAEBGG" alt="CodeCov"/>
+    </a>
 <p>
 <p align="center">
     <img src="https://img.shields.io/github/v/release/mguyard/hass-iopool?label=Stable" alt="Last Stable Release">

--- a/custom_components/iopool/manifest.json
+++ b/custom_components/iopool/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/mguyard/hass-iopool/issues",
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "1.2.2"
+  "version": "1.2.3-beta.1"
 }

--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -177,6 +177,7 @@ async def async_setup_entry(
                 name=friendly_name,
                 unique_id=f"{entry.entry_id}_{pool_id}_{SENSOR_ELAPSED_FILTRATION}",
                 source_entity_id=f"sensor.iopool_{pool.title.lower().replace(' ', '_')}_{SENSOR_TEMPERATURE}",
+                state_class=SensorStateClass.MEASUREMENT,
             )
             history_stats_entity.entity_id = f"sensor.iopool_{pool.title.lower().replace(' ', '_')}_{SENSOR_ELAPSED_FILTRATION}"
             # Add the entity to Home Assistant

--- a/custom_components/iopool/tests/test_sensor.py
+++ b/custom_components/iopool/tests/test_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.iopool.const import DOMAIN
 from custom_components.iopool.sensor import (
@@ -323,7 +323,7 @@ class TestAsyncSetupEntryEdgeCases:
         mock_history_stats.return_value = MagicMock()
 
         mock_history_coordinator = MagicMock()
-        mock_history_coordinator.async_config_entry_first_refresh = MagicMock(
+        mock_history_coordinator.async_config_entry_first_refresh = AsyncMock(
             return_value=None
         )
         mock_coordinator_class.return_value = mock_history_coordinator
@@ -339,8 +339,11 @@ class TestAsyncSetupEntryEdgeCases:
         mock_template.assert_called()
         mock_history_stats.assert_called_once()
         mock_coordinator_class.assert_called_once()
-        # Note: HistoryStatsSensor is called but within a try/except that might fail
-        # So we just verify that basic entities were added
+        # Verify HistoryStatsSensor was called with state_class=MEASUREMENT (required since HA 2026.3)
+        mock_sensor_class.assert_called_once()
+        call_kwargs = mock_sensor_class.call_args[1]
+        from homeassistant.components.sensor import SensorStateClass
+        assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
         assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio
@@ -400,7 +403,9 @@ class TestAsyncSetupEntryEdgeCases:
         mock_history_stats.return_value = MagicMock()
 
         mock_history_coordinator = MagicMock()
-        mock_history_coordinator.async_config_entry_first_refresh = MagicMock()
+        mock_history_coordinator.async_config_entry_first_refresh = AsyncMock(
+            return_value=None
+        )
         mock_coordinator_class.return_value = mock_history_coordinator
 
         mock_history_sensor = MagicMock()
@@ -411,11 +416,16 @@ class TestAsyncSetupEntryEdgeCases:
         await async_setup_entry(hass, config_entry, mock_async_add_entities)
 
         # Verify French language template was used
-        # This is indirectly tested by checking that the coordinator was created
         mock_coordinator_class.assert_called_once()
         call_args = mock_coordinator_class.call_args[0]
         friendly_name = call_args[3]  # 4th argument is friendly_name
         assert friendly_name == "Piscine Test Durée de filtration écoulée aujourd'hui"
+        # Verify HistoryStatsSensor was called with state_class=MEASUREMENT (required since HA 2026.3)
+        mock_sensor_class.assert_called_once()
+        call_kwargs = mock_sensor_class.call_args[1]
+        from homeassistant.components.sensor import SensorStateClass
+        assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
+        assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio
     @patch("homeassistant.helpers.template.Template")

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "iopool",
     "country": "FR",
-    "homeassistant": "2025.2.0"
+    "homeassistant": "2026.3.0"
 }


### PR DESCRIPTION
## Summary

This PR promotes the `beta` branch to `main`, releasing version **1.2.3** with a critical bug fix for Home Assistant 2026.3 compatibility.

---

## Commits

- **fix(sensor): 🐛 Add required `state_class` to `HistoryStatsSensor`**
  HA 2026.3 ([home-assistant/core#148637](https://github.com/home-assistant/core/issues/148637)) made `state_class` a mandatory keyword-only parameter of `HistoryStatsSensor.__init__()`. Omitting it was raising a `TypeError` silently caught by the `except` block, preventing sensor creation.
  → [b3a7b8c](https://github.com/mguyard/hass-iopool/commit/b3a7b8ccc9fe010ac296e88ddab657ddadaaaa14) — Closes #51

- **chore(deps): 🔧 Bump minimum HA version to 2026.3.0**
  Required since `HistoryStatsSensor` now mandates `state_class`.
  → [1de10df](https://github.com/mguyard/hass-iopool/commit/1de10dff179c6c2a7914fe63e28657d16321df21)

- **test(sensor): ✅ Fix mocks and assert `state_class` on HistoryStatsSensor**
  Replace `MagicMock` with `AsyncMock` for `async_config_entry_first_refresh`; add `state_class` assertion on `HistoryStatsSensor` in both EN and FR test variants.
  → [6d6634c](https://github.com/mguyard/hass-iopool/commit/6d6634c4f4c61d7e7363293cd5832881e1ccbded)

- **docs: 📝 Fix CodeCov badge with proper link wrapper**
  → [d65d9da](https://github.com/mguyard/hass-iopool/commit/d65d9da4586a62bf201fefa09d6b236de5769bea)

- **docs(testing): 📝 Update testing instructions for devcontainer setup**
  Added steps to detect if running inside the devcontainer; clarified commands for running tests directly and via Docker.
  → [a8a5183](https://github.com/mguyard/hass-iopool/commit/a8a5183be20ee9c9ea159299e97432cbde244502)

---

Closes #51