### PR TITLE
fix(sensor): 🐛 Fix HistoryStats incompatibility with HA 2026.4 + dependency bumps

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Find last tested version artifact
         if: github.event_name == 'schedule'
         id: find-artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const artifactName = 'last-tested-${{ matrix.home-assistant-version }}-version';

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -348,7 +348,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.home-assistant-version == 'stable' && env.SKIP_TESTS != 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/hass-config/coverage.xml
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && env.SKIP_TESTS != 'true' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/hass-config/junit.xml

--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from typing import Any
 
@@ -158,6 +158,7 @@ async def async_setup_entry(
             start=start_template,
             end=end_template,
             duration=None,
+            min_state_duration=timedelta(0),
         )
         # Create the coordinator
         coordinator = HistoryStatsUpdateCoordinator(

--- a/custom_components/iopool/tests/test_sensor.py
+++ b/custom_components/iopool/tests/test_sensor.py
@@ -344,6 +344,10 @@ class TestAsyncSetupEntryEdgeCases:
         call_kwargs = mock_sensor_class.call_args[1]
         from homeassistant.components.sensor import SensorStateClass
         assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
+        # Verify HistoryStats was called with min_state_duration=timedelta(0) (required since HA 2026.4)
+        from datetime import timedelta
+        hs_call_kwargs = mock_history_stats.call_args[1]
+        assert hs_call_kwargs.get("min_state_duration") == timedelta(0)
         assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio
@@ -425,6 +429,10 @@ class TestAsyncSetupEntryEdgeCases:
         call_kwargs = mock_sensor_class.call_args[1]
         from homeassistant.components.sensor import SensorStateClass
         assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
+        # Verify HistoryStats was called with min_state_duration=timedelta(0) (required since HA 2026.4)
+        from datetime import timedelta
+        hs_call_kwargs = mock_history_stats.call_args[1]
+        assert hs_call_kwargs.get("min_state_duration") == timedelta(0)
         assert mock_async_add_entities.call_count >= 1
 
     @pytest.mark.asyncio

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "iopool",
     "country": "FR",
-    "homeassistant": "2026.3.0"
+    "homeassistant": "2026.4.0"
 }


### PR DESCRIPTION
## Summary

This PR brings `dev` into `beta` with a critical bug fix for Home Assistant 2026.4 compatibility and two CI dependency bumps.

---

## Commits

### Bug Fix

- **fix(sensor): 🐛 Add required `min_state_duration` to `HistoryStats`**
  `HistoryStats.__init__()` requires a `min_state_duration` argument since HA 2026.4. Pass `timedelta(0)` (equivalent to `DEFAULT_MIN_STATE_DURATION`) to preserve existing behavior — all on-periods are counted.
  → [85883a0](https://github.com/mguyard/hass-iopool/commit/85883a0c8ba363c6638f712ab3f4b1a6e096eb32) — Closes #53

- **chore(deps): 🔧 Bump minimum HA version to 2026.4.0**
  Required since `HistoryStats` now mandates `min_state_duration`.
  → [3edc4d5](https://github.com/mguyard/hass-iopool/commit/3edc4d5ca08af6e92185eca1e723238ca9c50472)

- **test(sensor): ✅ Assert `min_state_duration` on `HistoryStats` call**
  Add assertion in both EN and FR test variants to verify that `HistoryStats` is called with `min_state_duration=timedelta(0)` as required since HA 2026.4.
  → [8c17c53](https://github.com/mguyard/hass-iopool/commit/8c17c53ee6a1e8caac5f00c2db883e175e58eb0d)

### Dependency Updates (Dependabot)

- **chore(deps): bump `codecov/codecov-action` from 5 to 6**
  → [fddafea](https://github.com/mguyard/hass-iopool/commit/fddafea511c7f8c168efe4639e7aaef21f89f624)

- **chore(deps): bump `actions/github-script` from 7 to 8**
  → [2418920](https://github.com/mguyard/hass-iopool/commit/2418920cff1fc97b1058ba31d100e66543720b70)

---

Closes #53