### PR TITLE
fix(filtration): 🐛 Use instance vars as reliable source for stop scheduling

### DIFF
--- a/custom_components/iopool/binary_sensor.py
+++ b/custom_components/iopool/binary_sensor.py
@@ -169,6 +169,14 @@ class IopoolBinarySensor(CoordinatorEntity, BinarySensorEntity, RestoreEntity):
                     self.hass.states.async_set(
                         self.entity_id, "off", last_state.attributes
                     )
+            # Restore filtration operational state into Filtration instance variables.
+            # This ensures next_stop_time and active_slot survive a HA restart so
+            # the periodic stop check resumes correctly without relying on HA state.
+            if last_state is not None:
+                self._filtration.restore_filtration_state(
+                    last_state.attributes.get("next_stop_time"),
+                    last_state.attributes.get("active_slot"),
+                )
             # Set up listener for switch state changes
             switch_entity = self._filtration.get_switch_entity()
             if switch_entity:
@@ -313,17 +321,21 @@ class IopoolBinarySensor(CoordinatorEntity, BinarySensorEntity, RestoreEntity):
                             attributes["slot2_start_time"] = dt_util.as_local(
                                 slot2_start_time
                             ).isoformat()
-                    # Preserve existing attributes that we want to keep
+                    # Preserve slot end times from HA state
                     preserved_attrs = [
                         "slot1_end_time",
                         "slot2_end_time",
-                        "next_stop_time",
-                        "active_slot",
                     ]
                     if state and state.attributes:
                         for attr in preserved_attrs:
                             if attr in state.attributes:
                                 attributes[attr] = state.attributes[attr]
+                    # Read operational state from filtration instance variables
+                    # (reliable source of truth, not affected by coordinator failures)
+                    if filtration.get_next_stop_time() is not None:
+                        attributes["next_stop_time"] = filtration.get_next_stop_time()
+                    if filtration.get_active_slot() is not None:
+                        attributes["active_slot"] = filtration.get_active_slot()
 
                 # If pool_mode is Active-Winter and winter filtration is enabled
                 if (
@@ -361,15 +373,12 @@ class IopoolBinarySensor(CoordinatorEntity, BinarySensorEntity, RestoreEntity):
                         attributes["winter_filtration_end"] = dt_util.as_local(
                             winter_filtration_end
                         ).isoformat()
-                    # Preserve existing attributes that we want to keep
-                    preserved_attrs = [
-                        "next_stop_time",
-                        "active_slot",
-                    ]
-                    if state and state.attributes:
-                        for attr in preserved_attrs:
-                            if attr in state.attributes:
-                                attributes[attr] = state.attributes[attr]
+                    # Read operational state from filtration instance variables
+                    # (reliable source of truth, not affected by coordinator failures)
+                    if filtration.get_next_stop_time() is not None:
+                        attributes["next_stop_time"] = filtration.get_next_stop_time()
+                    if filtration.get_active_slot() is not None:
+                        attributes["active_slot"] = filtration.get_active_slot()
                 if pool_mode == "Passive-Winter":
                     # If pool_mode is Passive-Winter and other mode attributes are set,
                     # we remove them to avoid confusion

--- a/custom_components/iopool/filtration.py
+++ b/custom_components/iopool/filtration.py
@@ -72,6 +72,12 @@ class Filtration:
             self.config_filtration_winter_enabled()
         )
         self.configuration_filtration_enabled = self.config_filtration_enabled()
+        # Instance variables for reliable operational state tracking.
+        # These are the source of truth for stop scheduling and survive
+        # coordinator failures, entity unavailability, and HA restarts
+        # (values are restored in IopoolBinarySensor.async_added_to_hass).
+        self._next_stop_time: str | None = None
+        self._active_slot: str | int | None = None
 
     def config_filtration_summer_enabled(self) -> bool:
         """Determine if summer filtration is enabled in the configuration.
@@ -516,11 +522,62 @@ class Filtration:
         if active_slot is None and "active_slot" in attributes:
             attributes.pop("active_slot")
 
+        # Update instance variables for reliable stop/start tracking.
+        # These survive coordinator failures and HA entity unavailability.
+        self._next_stop_time = next_stop_time
+        self._active_slot = active_slot
+
         # Update the state
         self._entry.runtime_data.coordinator.hass.states.async_set(
             entity_id, state.state, attributes
         )
         _LOGGER.debug("Updated filtration attributes: %s", attributes)
+
+    def restore_filtration_state(
+        self,
+        next_stop_time: str | None,
+        active_slot: str | int | None,
+    ) -> None:
+        """Restore filtration operational state after HA restart.
+
+        Called by IopoolBinarySensor.async_added_to_hass to populate instance
+        variables from the previously persisted HA state attributes, ensuring
+        the stop scheduler can resume correctly after a restart.
+
+        Args:
+            next_stop_time: ISO formatted datetime string for the next scheduled stop,
+                            or None if no stop was scheduled.
+            active_slot: The active filtration slot (1, 2, "winter", "boost") or None.
+
+        Returns:
+            None
+
+        """
+        self._next_stop_time = next_stop_time
+        self._active_slot = active_slot
+        _LOGGER.debug(
+            "Restored filtration operational state: next_stop_time=%s, active_slot=%s",
+            next_stop_time,
+            active_slot,
+        )
+
+    def get_next_stop_time(self) -> str | None:
+        """Return the current scheduled stop time for filtration.
+
+        Returns:
+            str | None: ISO formatted datetime string, or None if no stop is scheduled.
+
+        """
+        return self._next_stop_time
+
+    def get_active_slot(self) -> str | int | None:
+        """Return the currently active filtration slot.
+
+        Returns:
+            str | int | None: The active slot (1, 2, "winter", "boost") or None.
+
+        """
+        return self._active_slot
 
     async def check_filtration_status(self, now: datetime) -> None:
         """Periodically checks and manages the filtration system status.
@@ -585,6 +642,15 @@ class Filtration:
                 boost_state,
             )
 
+            # Retrieve the next scheduled stop time from instance variable.
+            # This is reliable: not affected by coordinator failures or entity
+            # unavailability, unlike reading from the HA state attributes.
+            next_stop_time = self._next_stop_time
+            _LOGGER.debug("Next stop time for filtration: %s", next_stop_time)
+            if not next_stop_time:
+                _LOGGER.debug("No next stop time set, skipping filtration stop check")
+                return
+
             _, _, filtration_attributes = await self.get_filtration_attributes()
 
             # if boost_state and boost_state.state not in (None, "none", "None"):
@@ -597,13 +663,6 @@ class Filtration:
             #             next_stop_time=None, active_slot="boost"
             #         )
             #     return
-
-            # Retrieve the next scheduled stop time from binary sensor attributes
-            next_stop_time = filtration_attributes.get("next_stop_time")
-            _LOGGER.debug("Next stop time for filtration: %s", next_stop_time)
-            if not next_stop_time:
-                _LOGGER.debug("No next stop time set, skipping filtration stop check")
-                return
 
             try:
                 # Parse the next_stop_time which is in local timezone
@@ -639,7 +698,7 @@ class Filtration:
 
                 if next_stop_dt and now_local >= next_stop_dt:
                     # Check if active_slot is 2 and if elapsed filtration is enough
-                    if filtration_attributes.get("active_slot", None) == 2:
+                    if self._active_slot == 2:
                         if elapsed_filtration_duration_state:
                             remaining_duration_min = round(
                                 int(
@@ -725,7 +784,7 @@ class Filtration:
                     # Prepare event data based on active slot
                     event_type = None
                     event = None
-                    match filtration_attributes.get("active_slot"):
+                    match self._active_slot:
                         case 1:
                             event_type = EVENT_TYPE_SLOT1_END
                             event = {

--- a/custom_components/iopool/tests/test_binary_sensor.py
+++ b/custom_components/iopool/tests/test_binary_sensor.py
@@ -654,8 +654,6 @@ class TestIopoolBinarySensor:
         state_mock.attributes = {
             "slot1_end_time": "existing_end_time",
             "slot2_end_time": "existing_slot2_end",
-            "next_stop_time": "existing_stop_time",
-            "active_slot": "existing_slot",
         }
         hass.states.get.return_value = state_mock
 
@@ -663,6 +661,9 @@ class TestIopoolBinarySensor:
         mock_filtration = mock_iopool_coordinator.config_entry.runtime_data.filtration
         mock_filtration.get_filtration_pool_mode.return_value = "Standard"
         mock_filtration.configuration_filtration_enabled_summer = True
+        # next_stop_time and active_slot now come from filtration instance variables
+        mock_filtration.get_next_stop_time.return_value = "existing_stop_time"
+        mock_filtration.get_active_slot.return_value = "existing_slot"
 
         # Mock slot times
         slot1_start = datetime(2024, 1, 1, 9, 0)
@@ -686,15 +687,61 @@ class TestIopoolBinarySensor:
         assert "slot1_start_time" in attributes
         assert "slot2_start_time" in attributes
 
-        # Preserved attributes should remain
+        # Slot end times preserved from HA state
         assert "slot1_end_time" in attributes
         assert attributes["slot1_end_time"] == "existing_end_time"
         assert "slot2_end_time" in attributes
         assert attributes["slot2_end_time"] == "existing_slot2_end"
+        # next_stop_time and active_slot come from filtration instance variables
         assert "next_stop_time" in attributes
         assert attributes["next_stop_time"] == "existing_stop_time"
         assert "active_slot" in attributes
         assert attributes["active_slot"] == "existing_slot"
+
+    def test_extra_state_attributes_filtration_winter_no_next_stop(
+        self,
+        mock_iopool_coordinator,
+        mock_api_response,
+        hass,
+    ) -> None:
+        """Test winter mode attributes when next_stop_time is None (coordinator failure scenario)."""
+        sensor_description = POOL_BINARY_SENSORS_CONDITIONAL_FILTRATION[0]  # filtration
+        sensor = IopoolBinarySensor(
+            mock_iopool_coordinator,
+            sensor_description,
+            "test_entry_id",
+            TEST_POOL_ID,
+            TEST_POOL_TITLE,
+        )
+
+        sensor.hass = hass
+        # Simulate state where pool_mode was temporarily "unavailable"
+        state_mock = MagicMock()
+        state_mock.attributes = {}
+        hass.states.get.return_value = state_mock
+
+        mock_filtration = mock_iopool_coordinator.config_entry.runtime_data.filtration
+        mock_filtration.get_filtration_pool_mode.return_value = "Active-Winter"
+        mock_filtration.configuration_filtration_enabled_winter = True
+        # Instance variables hold the operational state reliably
+        mock_filtration.get_next_stop_time.return_value = "2026-03-28T04:00:00+01:00"
+        mock_filtration.get_active_slot.return_value = "winter"
+
+        winter_start_time = time(2, 0)
+        winter_duration = timedelta(hours=2)
+        mock_filtration.get_winter_filtration_start_end.return_value = (
+            winter_start_time,
+            winter_duration,
+        )
+
+        mock_iopool_coordinator.get_pool_data.return_value = mock_api_response.pools[0]
+        attributes = sensor.extra_state_attributes
+
+        # next_stop_time and active_slot must be present even if pool_mode was unavailable
+        assert "next_stop_time" in attributes
+        assert attributes["next_stop_time"] == "2026-03-28T04:00:00+01:00"
+        assert "active_slot" in attributes
+        assert attributes["active_slot"] == "winter"
 
     def test_icon_property(
         self,
@@ -712,3 +759,69 @@ class TestIopoolBinarySensor:
 
         assert sensor.icon == sensor_description.icon
         assert sensor.icon == "mdi:gesture-tap-button"
+
+    @pytest.mark.asyncio
+    async def test_async_added_to_hass_restores_filtration_state(
+        self,
+        mock_iopool_coordinator,
+        hass,
+    ) -> None:
+        """Test that async_added_to_hass restores filtration instance variables."""
+        sensor_description = POOL_BINARY_SENSORS_CONDITIONAL_FILTRATION[0]  # filtration
+        sensor = IopoolBinarySensor(
+            mock_iopool_coordinator,
+            sensor_description,
+            "test_entry_id",
+            TEST_POOL_ID,
+            TEST_POOL_TITLE,
+        )
+        sensor.hass = hass
+
+        # Simulate a restored state with next_stop_time and active_slot
+        last_state = MagicMock()
+        last_state.state = "on"
+        last_state.attributes = {
+            "next_stop_time": "2026-03-28T04:00:00+01:00",
+            "active_slot": "winter",
+            "filtration_mode": "Active-Winter",
+        }
+        sensor.async_get_last_state = AsyncMock(return_value=last_state)
+
+        mock_filtration = mock_iopool_coordinator.config_entry.runtime_data.filtration
+        mock_filtration.get_switch_entity.return_value = None
+
+        sensor.async_on_remove = MagicMock()
+
+        await sensor.async_added_to_hass()
+
+        # restore_filtration_state must have been called with correct values
+        mock_filtration.restore_filtration_state.assert_called_once_with(
+            "2026-03-28T04:00:00+01:00",
+            "winter",
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_added_to_hass_no_last_state_no_restore(
+        self,
+        mock_iopool_coordinator,
+        hass,
+    ) -> None:
+        """Test that restore_filtration_state is not called when there is no last state."""
+        sensor_description = POOL_BINARY_SENSORS_CONDITIONAL_FILTRATION[0]  # filtration
+        sensor = IopoolBinarySensor(
+            mock_iopool_coordinator,
+            sensor_description,
+            "test_entry_id",
+            TEST_POOL_ID,
+            TEST_POOL_TITLE,
+        )
+        sensor.hass = hass
+        sensor.async_get_last_state = AsyncMock(return_value=None)
+
+        mock_filtration = mock_iopool_coordinator.config_entry.runtime_data.filtration
+        mock_filtration.get_switch_entity.return_value = None
+        sensor.async_on_remove = MagicMock()
+
+        await sensor.async_added_to_hass()
+
+        mock_filtration.restore_filtration_state.assert_not_called()

--- a/custom_components/iopool/tests/test_filtration.py
+++ b/custom_components/iopool/tests/test_filtration.py
@@ -125,6 +125,79 @@ class TestFiltration:
         assert filtration.configuration_filtration_enabled_summer is True
         assert filtration.configuration_filtration_enabled_winter is True
         assert filtration.configuration_filtration_enabled is True
+        # Instance variables must start as None
+        assert filtration._next_stop_time is None
+        assert filtration._active_slot is None
+
+    def test_restore_filtration_state(self, filtration: Filtration) -> None:
+        """Test restore_filtration_state sets instance variables."""
+        filtration.restore_filtration_state("2026-03-28T04:00:00+01:00", "winter")
+        assert filtration._next_stop_time == "2026-03-28T04:00:00+01:00"
+        assert filtration._active_slot == "winter"
+
+    def test_restore_filtration_state_none(self, filtration: Filtration) -> None:
+        """Test restore_filtration_state accepts None values."""
+        filtration.restore_filtration_state(None, None)
+        assert filtration._next_stop_time is None
+        assert filtration._active_slot is None
+
+    def test_get_next_stop_time(self, filtration: Filtration) -> None:
+        """Test get_next_stop_time returns the instance variable."""
+        assert filtration.get_next_stop_time() is None
+        filtration._next_stop_time = "2026-03-28T04:00:00+01:00"
+        assert filtration.get_next_stop_time() == "2026-03-28T04:00:00+01:00"
+
+    def test_get_active_slot(self, filtration: Filtration) -> None:
+        """Test get_active_slot returns the instance variable."""
+        assert filtration.get_active_slot() is None
+        filtration._active_slot = "winter"
+        assert filtration.get_active_slot() == "winter"
+        filtration._active_slot = 2
+        assert filtration.get_active_slot() == 2
+
+    async def test_update_filtration_attributes_sets_instance_vars(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test that update_filtration_attributes updates instance variables."""
+        # Mock get_filtration_attributes to return a valid state
+        mock_state = MagicMock()
+        mock_state.state = "on"
+        mock_state.attributes = {}
+        with patch.object(
+            filtration,
+            "get_filtration_attributes",
+            return_value=("binary_sensor.iopool_filtration", mock_state, {}),
+        ):
+            await filtration.update_filtration_attributes(
+                next_stop_time="2026-03-28T04:00:00+01:00",
+                active_slot="winter",
+            )
+        assert filtration._next_stop_time == "2026-03-28T04:00:00+01:00"
+        assert filtration._active_slot == "winter"
+
+    async def test_update_filtration_attributes_clears_instance_vars(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test that update_filtration_attributes clears instance variables when None."""
+        filtration._next_stop_time = "2026-03-28T04:00:00+01:00"
+        filtration._active_slot = "winter"
+        mock_state = MagicMock()
+        mock_state.state = "on"
+        mock_state.attributes = {
+            "next_stop_time": "2026-03-28T04:00:00+01:00",
+            "active_slot": "winter",
+        }
+        with patch.object(
+            filtration,
+            "get_filtration_attributes",
+            return_value=("binary_sensor.iopool_filtration", mock_state, dict(mock_state.attributes)),
+        ):
+            await filtration.update_filtration_attributes(
+                next_stop_time=None,
+                active_slot=None,
+            )
+        assert filtration._next_stop_time is None
+        assert filtration._active_slot is None
 
     def test_config_filtration_summer_enabled_true(
         self, filtration: Filtration


### PR DESCRIPTION
## Summary

This PR fixes a reliability bug where the filtration stop scheduler could lose track of the scheduled stop time when a transient API error occurred, causing the pump to run indefinitely.

### Root cause

`next_stop_time` and `active_slot` were stored exclusively as HA state attributes on the filtration binary sensor. These attributes were recomputed on every `extra_state_attributes` call, which reads `pool_mode` from the `IopoolSelect` entity. When the coordinator raised `UpdateFailed` (e.g. DNS timeout), `IopoolSelect.available` became `False` and its state was set to `"unavailable"`. The binary sensor then computed `pool_mode = "unavailable"`, no `if` block matched, and `next_stop_time` / `active_slot` were silently dropped from the attributes. The periodic `check_filtration_status` found `next_stop_time = None` and returned early without stopping the pump.

### Changes

#### `custom_components/iopool/filtration.py` — [04dd8d7](https://github.com/mguyard/hass-iopool/commit/04dd8d7)

- Add `_next_stop_time: str | None` and `_active_slot: str | int | None` instance variables to `Filtration.__init__` (initialised to `None`)
- `update_filtration_attributes()` now also sets those instance variables alongside the HA state update
- `check_filtration_status()` reads `next_stop_time` / `active_slot` from instance variables instead of HA state attributes — immune to coordinator failures and entity unavailability
- Add three new public methods:
  - `restore_filtration_state(next_stop_time, active_slot)` — called on HA restart to re-populate instance variables from persisted state
  - `get_next_stop_time() -> str | None`
  - `get_active_slot() -> str | int | None`

#### `custom_components/iopool/binary_sensor.py` — [04dd8d7](https://github.com/mguyard/hass-iopool/commit/04dd8d7)

- `async_added_to_hass()` calls `restore_filtration_state()` from `last_state.attributes` after a HA restart, ensuring the stop scheduler resumes correctly
- `extra_state_attributes` for `Standard` and `Active-Winter` modes now reads `next_stop_time` / `active_slot` from `filtration.get_next_stop_time()` / `filtration.get_active_slot()` — the HA state is used for display only, not as the source of truth

#### `custom_components/iopool/tests/test_filtration.py` — [04dd8d7](https://github.com/mguyard/hass-iopool/commit/04dd8d7)

- `test_init`: asserts `_next_stop_time` and `_active_slot` start as `None`
- New: `test_restore_filtration_state`, `test_restore_filtration_state_none`
- New: `test_get_next_stop_time`, `test_get_active_slot`
- New: `test_update_filtration_attributes_sets_instance_vars`, `test_update_filtration_attributes_clears_instance_vars`

#### `custom_components/iopool/tests/test_binary_sensor.py` — [04dd8d7](https://github.com/mguyard/hass-iopool/commit/04dd8d7)

- `test_extra_state_attributes_filtration_summer_with_slot2`: updated to mock `get_next_stop_time()` / `get_active_slot()` instead of HA state attributes
- New: `test_extra_state_attributes_filtration_winter_no_next_stop` — verifies `next_stop_time` is present in attributes even when the HA state was transiently unavailable
- New: `test_async_added_to_hass_restores_filtration_state` — verifies `restore_filtration_state()` is called with the correct values on restart
- New: `test_async_added_to_hass_no_last_state_no_restore` — verifies `restore_filtration_state()` is not called when there is no persisted state

**All 225 tests pass.**