### PR TITLE
fix(filtration): 🐛 Fix winter end event not fired due to wrong attr key

### DIFF
--- a/.github/agents/coder-jr.agent.md
+++ b/.github/agents/coder-jr.agent.md
@@ -83,6 +83,7 @@ You are an efficient junior developer optimized for speed on straightforward cod
 2. If edit/write tools are unavailable, stop immediately and return exactly: `EDIT_TOOLS_UNAVAILABLE`.
 3. Do NOT output full-file replacements or multi-file code dumps as a fallback.
 4. Wait for Orchestrator to re-run delegation in write-capable mode.
+5. **GitHub interactions**: `gh` CLI is NOT installed. Use MCP GitHub tools exclusively (see `@skills/git-conventions/SKILL.md §0`). Never fall back to `gh` commands.
 
 ## Tool Preflight (When Requested)
 

--- a/.github/agents/coder-sr.agent.md
+++ b/.github/agents/coder-sr.agent.md
@@ -47,6 +47,7 @@ If delegated to work in a **git worktree** (Orchestrator will specify the worktr
 2. If edit/write tools are unavailable, stop immediately and return exactly: `EDIT_TOOLS_UNAVAILABLE`.
 3. Do NOT output full-file replacements or multi-file code dumps as a fallback.
 4. Wait for Orchestrator to re-run delegation in write-capable mode.
+5. **GitHub interactions**: `gh` CLI is NOT installed. Use MCP GitHub tools exclusively (see `@skills/git-conventions/SKILL.md §0`). Never fall back to `gh` commands.
 
 ## Tool Preflight (When Requested)
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -6,7 +6,7 @@ model: Claude Sonnet 4.6 (copilot)
 target: vscode
 user-invocable: true
 disable-model-invocation: true
-tools: [read/readFile, agent, vscode/memory]
+tools: [agent, vscode/memory, vscode/askQuestions, read/readFile]
 agents:
   [
     Planner,

--- a/.github/skills/git-conventions/SKILL.md
+++ b/.github/skills/git-conventions/SKILL.md
@@ -10,6 +10,26 @@ Use this skill for any commit, PR creation, or pre-commit verification task in t
 
 ---
 
+## 0. GitHub Tooling (Mandatory)
+
+> **`gh` CLI is NOT installed and must NEVER be used.**
+
+All GitHub interactions (creating issues, posting comments, creating/updating PRs, reading PR diffs, searching issues, etc.) **must use MCP GitHub tools exclusively**:
+
+| Operation | MCP tool to use |
+|-----------|----------------|
+| Create issue | `mcp_github_create_issue` |
+| Add issue comment | `mcp_github_add_issue_comment` |
+| Update issue comment | `mcp_github_update_issue_comment` |
+| Create PR | `mcp_github_create_pull_request` |
+| Get PR diff | `mcp_github_get_pull_request_diff` |
+| Search issues/PRs | `mcp_github_search_issues` |
+| Get file contents | `mcp_github_get_file_contents` |
+
+If a MCP GitHub tool is unavailable for a specific operation, stop and report the gap to the Orchestrator. Do **not** fall back to `gh` CLI commands.
+
+---
+
 ## 1. Commit Message Format
 
 ```

--- a/custom_components/iopool/filtration.py
+++ b/custom_components/iopool/filtration.py
@@ -786,23 +786,13 @@ class Filtration:
                     event = None
                     match self._active_slot:
                         case 1:
+                            slot1_start_str = filtration_attributes.get("slot1_start_time")
+                            slot1_start_dt = dt_util.parse_datetime(slot1_start_str) if slot1_start_str else None
                             event_type = EVENT_TYPE_SLOT1_END
                             event = {
-                                "start_time": dt_util.parse_datetime(
-                                    filtration_attributes.get("slot1_start_time", None)
-                                ),
+                                "start_time": slot1_start_dt,
                                 "end_time": now.isoformat(),
-                                "duration_minutes": int(
-                                    (
-                                        now
-                                        - dt_util.parse_datetime(
-                                            filtration_attributes.get(
-                                                "slot1_start_time", None
-                                            )
-                                        )
-                                    ).total_seconds()
-                                    / 60
-                                ),
+                                "duration_minutes": int((now - slot1_start_dt).total_seconds() / 60) if slot1_start_dt else 0,
                                 "boost_in_progress": boost_state.state,
                                 "remaining_boost_duration_minutes": boost_remaining_duration,
                                 "day_filtration_objective_minutes": day_filtration_objective_minutes,
@@ -810,23 +800,13 @@ class Filtration:
                                 "day_filtration_elapsed_percent": day_filtration_elapsed_percent,
                             }
                         case 2:
+                            slot2_start_str = filtration_attributes.get("slot2_start_time")
+                            slot2_start_dt = dt_util.parse_datetime(slot2_start_str) if slot2_start_str else None
                             event_type = EVENT_TYPE_SLOT2_END
                             event = {
-                                "start_time": dt_util.parse_datetime(
-                                    filtration_attributes.get("slot2_start_time", None)
-                                ),
+                                "start_time": slot2_start_dt,
                                 "end_time": now.isoformat(),
-                                "duration_minutes": int(
-                                    (
-                                        now
-                                        - dt_util.parse_datetime(
-                                            filtration_attributes.get(
-                                                "slot2_start_time", None
-                                            )
-                                        )
-                                    ).total_seconds()
-                                    / 60
-                                ),
+                                "duration_minutes": int((now - slot2_start_dt).total_seconds() / 60) if slot2_start_dt else 0,
                                 "boost_in_progress": boost_state.state,
                                 "remaining_boost_duration_minutes": boost_remaining_duration,
                                 "day_filtration_objective_minutes": day_filtration_objective_minutes,
@@ -834,23 +814,13 @@ class Filtration:
                                 "day_filtration_elapsed_percent": day_filtration_elapsed_percent,
                             }
                         case "winter":
+                            winter_start_str = filtration_attributes.get("winter_filtration_start")
+                            winter_start_dt = dt_util.parse_datetime(winter_start_str) if winter_start_str else None
                             event_type = EVENT_TYPE_WINTER_END
                             event = {
-                                "start_time": dt_util.parse_datetime(
-                                    filtration_attributes.get("winter_start_time", None)
-                                ),
+                                "start_time": winter_start_dt,
                                 "end_time": now.isoformat(),
-                                "duration_minutes": int(
-                                    (
-                                        now
-                                        - dt_util.parse_datetime(
-                                            filtration_attributes.get(
-                                                "winter_start_time", None
-                                            )
-                                        )
-                                    ).total_seconds()
-                                    / 60
-                                ),
+                                "duration_minutes": int((now - winter_start_dt).total_seconds() / 60) if winter_start_dt else 0,
                                 "boost_in_progress": boost_state.state,
                                 "remaining_boost_duration_minutes": boost_remaining_duration,
                                 "day_filtration_objective_minutes": day_filtration_objective_minutes,

--- a/custom_components/iopool/tests/test_filtration.py
+++ b/custom_components/iopool/tests/test_filtration.py
@@ -17,6 +17,8 @@ from custom_components.iopool.const import (
     CONF_OPTIONS_FILTRATION_SWITCH_ENTITY,
     CONF_OPTIONS_FILTRATION_WINTER,
     DOMAIN,
+    EVENT_TYPE_SLOT1_END,
+    EVENT_TYPE_WINTER_END,
 )
 from custom_components.iopool.filtration import Filtration
 from custom_components.iopool.models import IopoolConfigData, IopoolConfigEntry
@@ -730,3 +732,230 @@ class TestFiltration:
         # Test through public interface - when no state, get_switch_entity still works
         result = filtration.get_switch_entity()
         assert result == "switch.pool_pump"
+
+    # ---------------------------------------------------------------------------
+    # check_filtration_status — event payload correctness and None-guard tests
+    # ---------------------------------------------------------------------------
+
+    def _make_check_filtration_mocks(self, now_dt):
+        """Return (switch_state, boost_mock, mock_search, mock_get) helpers for check_filtration_status tests."""
+        switch_state = MagicMock()
+        switch_state.state = "on"
+        boost_mock = MagicMock()
+        boost_mock.state = "none"
+        boost_mock.attributes = {}
+
+        def mock_search(platform, pattern):
+            if "boost" in pattern:
+                return "select.boost_selector"
+            return None
+
+        def mock_get(eid):
+            if eid == "switch.pool_pump":
+                return switch_state
+            if eid == "select.boost_selector":
+                return boost_mock
+            return None
+
+        return switch_state, boost_mock, mock_search, mock_get
+
+    async def test_check_filtration_status_slot1_end_event_fired(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test that slot1 end event is fired with correct duration_minutes."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        start_dt = now - timedelta(minutes=90)
+        start_str = start_dt.isoformat()
+
+        filtration._active_slot = 1
+        filtration._next_stop_time = now.isoformat()
+        filtration_attrs = {
+            "slot1_start_time": start_str,
+            "filtration_duration_minutes": 120,
+        }
+        _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), filtration_attrs
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_publish.assert_called_once()
+        call_args = mock_publish.call_args
+        assert call_args[0][0] == EVENT_TYPE_SLOT1_END
+        event_payload = call_args[0][1]
+        assert event_payload["duration_minutes"] == 90
+        assert event_payload["start_time"] == dt_util.parse_datetime(start_str)
+
+    async def test_check_filtration_status_slot1_end_none_start_time(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test slot1 end event with missing slot1_start_time — no TypeError, duration_minutes=0."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 1
+        filtration._next_stop_time = now.isoformat()
+        filtration_attrs = {
+            # slot1_start_time deliberately absent
+            "filtration_duration_minutes": 120,
+        }
+        _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), filtration_attrs
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            # Must not raise TypeError
+            await filtration.check_filtration_status(now)
+
+        mock_publish.assert_called_once()
+        event_payload = mock_publish.call_args[0][1]
+        assert event_payload["duration_minutes"] == 0
+        assert event_payload["start_time"] is None
+
+    async def test_check_filtration_status_slot2_end_none_start_time(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test slot2 end event with missing slot2_start_time — no TypeError, duration_minutes=0."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 2
+        filtration._next_stop_time = now.isoformat()
+        filtration_attrs = {
+            # slot2_start_time deliberately absent
+            "filtration_duration_minutes": 120,
+        }
+        _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), filtration_attrs
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_publish.assert_called_once()
+        event_payload = mock_publish.call_args[0][1]
+        assert event_payload["duration_minutes"] == 0
+        assert event_payload["start_time"] is None
+
+    async def test_check_filtration_status_winter_end_event_correct_key(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test that winter end event reads 'winter_filtration_start' (not 'winter_start_time')."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        start_dt = now - timedelta(minutes=60)
+        start_str = start_dt.isoformat()
+        filtration._active_slot = "winter"
+        filtration._next_stop_time = now.isoformat()
+        filtration_attrs = {
+            "winter_filtration_start": start_str,   # correct key
+            # "winter_start_time" is intentionally absent to confirm only the right key is read
+        }
+        _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), filtration_attrs
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_publish.assert_called_once()
+        call_args = mock_publish.call_args
+        assert call_args[0][0] == EVENT_TYPE_WINTER_END
+        event_payload = call_args[0][1]
+        assert event_payload["duration_minutes"] == 60
+        assert event_payload["start_time"] == dt_util.parse_datetime(start_str)
+
+    async def test_check_filtration_status_winter_end_old_wrong_key_ignored(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test winter end event: old 'winter_start_time' key is ignored; duration_minutes=0."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        start_dt = now - timedelta(minutes=45)
+        filtration._active_slot = "winter"
+        filtration._next_stop_time = now.isoformat()
+        # Only the OLD wrong key present — should not be read
+        filtration_attrs = {
+            "winter_start_time": start_dt.isoformat(),   # old wrong key
+        }
+        _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), filtration_attrs
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            # Must not raise TypeError even when correct key is absent
+            await filtration.check_filtration_status(now)
+
+        mock_publish.assert_called_once()
+        event_payload = mock_publish.call_args[0][1]
+        assert event_payload["duration_minutes"] == 0
+        assert event_payload["start_time"] is None
+
+    async def test_check_filtration_status_winter_end_none_start_time(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """Test winter end with winter_filtration_start=None — no TypeError, duration_minutes=0."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = "winter"
+        filtration._next_stop_time = now.isoformat()
+        filtration_attrs = {}   # no winter_filtration_start at all
+        _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), filtration_attrs
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_publish.assert_called_once()
+        event_payload = mock_publish.call_args[0][1]
+        assert event_payload["duration_minutes"] == 0
+        assert event_payload["start_time"] is None


### PR DESCRIPTION
## Summary

Fix a bug in `filtration.py` where the scheduled end-of-cycle event (`EVENT_TYPE_WINTER_END`) was never fired during winter filtration mode. The root cause was a key mismatch between the attribute written by `binary_sensor.py` (`winter_filtration_start`) and the key read in `check_filtration_status()` (`winter_start_time`). Defensive `None`-guards were also added for `slot1_start_time` and `slot2_start_time` to prevent the same `TypeError` after an HA restart. Additionally, tooling rules were updated to enforce MCP GitHub tools over the `gh` CLI.

## Commits

- [`cb286ee`](https://github.com/mguyard/hass-iopool/commit/cb286ee) chore(git-conventions): 🔧 Update GitHub interaction guidelines
- [`757112a`](https://github.com/mguyard/hass-iopool/commit/757112a) fix(filtration): 🐛 Fix winter end event not fired due to wrong attr key
- [`251cf20`](https://github.com/mguyard/hass-iopool/commit/251cf20) chore(agents): 🔧 Update tools array in `orchestrator.agent.md`

## Tests

```bash
pytest custom_components/iopool/tests/ -v
✅ 239 passed, ❌ 0 failed, ⚠️ 0 errors
```

## Related Issues

Closes #65