### PR TITLE
fix(entity): 🐛 Normalize pool name slugs to valid entity IDs

### DIFF
--- a/custom_components/iopool/binary_sensor.py
+++ b/custom_components/iopool/binary_sensor.py
@@ -35,6 +35,7 @@ from .const import (
     SENSOR_FILTRATION,
 )
 from .coordinator import IopoolDataUpdateCoordinator
+from .entity import slugify_pool_name
 from .filtration import Filtration
 from .models import IopoolConfigData
 
@@ -133,7 +134,7 @@ class IopoolBinarySensor(CoordinatorEntity, BinarySensorEntity, RestoreEntity):
         self._filtration: Filtration = coordinator.config_entry.runtime_data.filtration
 
         # Convert pool_name to snake_case for consistency
-        snake_pool_name = pool_name.lower().replace(" ", "_")
+        snake_pool_name = slugify_pool_name(pool_name)
         self.entity_id = f"binary_sensor.iopool_{snake_pool_name}_{description.key}"
 
         # Create a unique DeviceInfo for each pool - must match the sensor platform

--- a/custom_components/iopool/entity.py
+++ b/custom_components/iopool/entity.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import re
+import unicodedata
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -9,6 +12,20 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .api_models import IopoolAPIResponsePool
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import IopoolDataUpdateCoordinator
+
+
+def slugify_pool_name(name: str) -> str:
+    """Convert a pool name to a valid entity ID slug.
+
+    Normalizes accented characters, lowercases, and replaces any sequence
+    of non-alphanumeric characters with a single underscore.
+    """
+    # Normalize accented characters via NFKD: à→a, é→e, ç→c, etc.
+    nfkd = unicodedata.normalize("NFKD", name)
+    ascii_name = nfkd.encode("ascii", "ignore").decode("ascii")
+    # Replace any sequence of non [a-z0-9] chars with a single underscore
+    slugged = re.sub(r"[^a-z0-9]+", "_", ascii_name.lower())
+    return slugged.strip("_")
 
 
 class IopoolEntity(CoordinatorEntity, RestoreEntity):

--- a/custom_components/iopool/select.py
+++ b/custom_components/iopool/select.py
@@ -24,7 +24,7 @@ from .const import (
     SENSOR_POOL_MODE,
 )
 from .coordinator import IopoolDataUpdateCoordinator
-from .entity import IopoolEntity
+from .entity import IopoolEntity, slugify_pool_name
 from .filtration import Filtration
 from .models import IopoolConfigData, IopoolConfigEntry
 
@@ -120,7 +120,7 @@ class IopoolSelect(IopoolEntity, SelectEntity):
         self._attr_unique_id = f"{config_entry_id}_{pool_id}_{description.key}"
 
         # Set custom entity_id with iopool_ prefix
-        snake_pool_name = pool_name.lower().replace(" ", "_")
+        snake_pool_name = slugify_pool_name(pool_name)
         self.entity_id = f"select.iopool_{snake_pool_name}_{description.key}"
 
     @property

--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -32,7 +32,7 @@ from .const import (
     SENSOR_TEMPERATURE,
 )
 from .coordinator import IopoolDataUpdateCoordinator
-from .entity import IopoolEntity
+from .entity import IopoolEntity, slugify_pool_name
 from .models import IopoolConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -177,10 +177,10 @@ async def async_setup_entry(
                 sensor_type=CONF_TYPE_TIME,
                 name=friendly_name,
                 unique_id=f"{entry.entry_id}_{pool_id}_{SENSOR_ELAPSED_FILTRATION}",
-                source_entity_id=f"sensor.iopool_{pool.title.lower().replace(' ', '_')}_{SENSOR_TEMPERATURE}",
+                source_entity_id=f"sensor.iopool_{slugify_pool_name(pool.title)}_{SENSOR_TEMPERATURE}",
                 state_class=SensorStateClass.MEASUREMENT,
             )
-            history_stats_entity.entity_id = f"sensor.iopool_{pool.title.lower().replace(' ', '_')}_{SENSOR_ELAPSED_FILTRATION}"
+            history_stats_entity.entity_id = f"sensor.iopool_{slugify_pool_name(pool.title)}_{SENSOR_ELAPSED_FILTRATION}"
             # Add the entity to Home Assistant
             async_add_entities([history_stats_entity])
         except (ValueError, KeyError, TypeError) as err:
@@ -206,7 +206,7 @@ class IopoolSensor(IopoolEntity, SensorEntity):
         self._attr_unique_id = f"{config_entry_id}_{pool_id}_{description.key}"
 
         # Set custom entity_id with iopool_ prefix
-        snake_pool_name = pool_name.lower().replace(" ", "_")
+        snake_pool_name = slugify_pool_name(pool_name)
         self.entity_id = f"sensor.iopool_{snake_pool_name}_{description.key}"
 
     @property

--- a/custom_components/iopool/tests/test_binary_sensor.py
+++ b/custom_components/iopool/tests/test_binary_sensor.py
@@ -163,6 +163,34 @@ class TestIopoolBinarySensor:
         assert sensor.has_entity_name is True
         assert sensor.translation_key == sensor_description.translation_key
 
+    @pytest.mark.parametrize(
+        ("pool_name", "expected_id_fragment"),
+        [
+            ("My Pool", "my_pool"),
+            ("Piscine été", "piscine_ete"),
+            ("aquarium à  pikatchu", "aquarium_a_pikatchu"),
+            ("Pool-Name", "pool_name"),
+            ("  Leading Spaces  ", "leading_spaces"),
+        ],
+    )
+    def test_binary_sensor_entity_id_slugified(
+        self,
+        mock_iopool_coordinator,
+        pool_name: str,
+        expected_id_fragment: str,
+    ) -> None:
+        """Test that binary sensor entity_id is properly slugified from the pool name."""
+        sensor_description = POOL_BINARY_SENSORS[0]  # action_required
+        sensor = IopoolBinarySensor(
+            mock_iopool_coordinator,
+            sensor_description,
+            "test_entry_id",
+            TEST_POOL_ID,
+            pool_name,
+        )
+        expected_entity_id = f"binary_sensor.iopool_{expected_id_fragment}_{sensor_description.key}"
+        assert sensor.entity_id == expected_entity_id
+
     def test_action_required_sensor_properties(
         self,
         mock_iopool_coordinator,

--- a/custom_components/iopool/tests/test_entity.py
+++ b/custom_components/iopool/tests/test_entity.py
@@ -1,0 +1,47 @@
+"""Tests for iopool entity base module, including slugify_pool_name."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.iopool.entity import slugify_pool_name
+
+
+class TestSlugifyPoolName:
+    """Tests for the slugify_pool_name helper function."""
+
+    @pytest.mark.parametrize(
+        ("input_name", "expected"),
+        [
+            # Standard case — no change in behavior
+            ("My Pool", "my_pool"),
+            # Numbers are preserved
+            ("Pool 123", "pool_123"),
+            # Accented char + double space collapses to single underscore
+            ("aquarium à  pikatchu", "aquarium_a_pikatchu"),
+            # Multiple accented chars
+            ("Piscine été", "piscine_ete"),
+            # Leading and trailing spaces are stripped
+            ("  Leading Spaces  ", "leading_spaces"),
+            # Hyphen is replaced by underscore
+            ("Pool-Name", "pool_name"),
+            # Tilde-combined chars (Ñ → N)
+            ("Ma Piscine Ñoño", "ma_piscine_nono"),
+        ],
+    )
+    def test_slugify_pool_name(self, input_name: str, expected: str) -> None:
+        """Test slugify_pool_name produces correct output for various inputs."""
+        assert slugify_pool_name(input_name) == expected
+
+    def test_already_clean_name(self) -> None:
+        """Test that an already-clean lowercase name passes through unchanged."""
+        assert slugify_pool_name("mypool") == "mypool"
+
+    def test_all_special_chars_stripped(self) -> None:
+        """Test that a name consisting only of special chars returns empty string."""
+        # All characters are non-alphanumeric; strip("_") yields ""
+        assert slugify_pool_name("---") == ""
+
+    def test_numeric_only(self) -> None:
+        """Test that a purely numeric name is preserved."""
+        assert slugify_pool_name("42") == "42"

--- a/custom_components/iopool/tests/test_select.py
+++ b/custom_components/iopool/tests/test_select.py
@@ -77,6 +77,36 @@ class TestIopoolSelect:
 
         assert select_entity.icon == select_description.icon
 
+    @pytest.mark.parametrize(
+        ("pool_name", "expected_id_fragment"),
+        [
+            ("My Pool", "my_pool"),
+            ("Piscine été", "piscine_ete"),
+            ("aquarium à  pikatchu", "aquarium_a_pikatchu"),
+            ("Pool-Name", "pool_name"),
+            ("  Leading Spaces  ", "leading_spaces"),
+        ],
+    )
+    def test_select_entity_id_slugified(
+        self,
+        mock_iopool_coordinator,
+        pool_name: str,
+        expected_id_fragment: str,
+    ) -> None:
+        """Test that select entity_id is properly slugified from the pool name."""
+        select_description = POOL_SELECTS_CONDITIONAL_FILTRATION[0]  # boost_selector
+        filtration_mock = MagicMock()
+        select_entity = IopoolSelect(
+            mock_iopool_coordinator,
+            filtration_mock,
+            select_description,
+            "test_entry_id",
+            TEST_POOL_ID,
+            pool_name,
+        )
+        expected_entity_id = f"select.iopool_{expected_id_fragment}_{select_description.key}"
+        assert select_entity.entity_id == expected_entity_id
+
 
 class TestIopoolSelectAdvanced:
     """Test advanced functionality."""

--- a/custom_components/iopool/tests/test_sensor.py
+++ b/custom_components/iopool/tests/test_sensor.py
@@ -147,6 +147,30 @@ class TestIopoolSensor:
         # Test that sensor was created with correct parameters
         assert sensor.unique_id is not None
 
+    @pytest.mark.parametrize(
+        ("pool_name", "expected_id_fragment"),
+        [
+            ("My Pool", "my_pool"),
+            ("Piscine été", "piscine_ete"),
+            ("aquarium à  pikatchu", "aquarium_a_pikatchu"),
+            ("Pool-Name", "pool_name"),
+            ("  Leading Spaces  ", "leading_spaces"),
+        ],
+    )
+    def test_sensor_entity_id_slugified(self, pool_name: str, expected_id_fragment: str) -> None:
+        """Test that sensor entity_id is properly slugified from the pool name."""
+        mock_coordinator = MagicMock()
+        sensor_description = POOL_SENSORS[0]  # Temperature sensor
+        sensor = IopoolSensor(
+            mock_coordinator,
+            sensor_description,
+            "test_entry_id",
+            TEST_POOL_ID,
+            pool_name,
+        )
+        expected_entity_id = f"sensor.iopool_{expected_id_fragment}_{sensor_description.key}"
+        assert sensor.entity_id == expected_entity_id
+
     def test_temperature_sensor_properties(self) -> None:
         """Test temperature sensor specific properties."""
         mock_coordinator = MagicMock()


### PR DESCRIPTION
## Summary

Fixes invalid entity IDs generated when a pool name contains accented characters (`à`, `é`, `ç`…) or multiple consecutive spaces. The naive `.lower().replace(" ", "_")` approach left accented characters intact and converted each space individually, producing IDs like `sensor.iopool_aquarium_à__pikatchu_temperature` which fail Home Assistant's entity ID validation (and will stop working in HA 2027.2.0).

A shared `slugify_pool_name()` utility is added to `entity.py` using Unicode NFKD normalization + regex collapse. It is applied consistently across all platforms (`sensor.py`, `binary_sensor.py`, `select.py`) including both the `HistoryStatsSensor` entity_id and its `source_entity_id` cross-reference, keeping internal references coherent.

Pool names using only ASCII letters, digits, and single spaces produce identical entity IDs as before — no migration needed for standard names.

## Commits

- [`5ab35e8`](https://github.com/mguyard/hass-iopool/commit/5ab35e8) fix(entity): 🐛 Normalize pool name slugs to valid entity IDs

## Tests

```
pytest custom_components/iopool/tests/ -v
✅ 264 passed, ❌ 0 failed, ⚠️ 0 errors
```

## Related Issues

Closes #67