### PR TITLE
chore: Publish beta release

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -348,7 +348,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.home-assistant-version == 'stable' && env.SKIP_TESTS != 'true'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/hass-config/coverage.xml
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && env.SKIP_TESTS != 'true' }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /tmp/hass-config/junit.xml


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by upgrading the Codecov GitHub Action from version 6 to version 7 for both coverage and test result uploads. This helps ensure compatibility with the latest features and fixes from Codecov.

- GitHub Actions workflow:
  * Updated `codecov/codecov-action` from `v6` to `v7` for uploading coverage and test results in `.github/workflows/tests.yaml`. [[1]](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191L351-R351) [[2]](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191L361-R361)