### PR TITLE
fix(sensor): 🐛 Stop dropping the history_stats sensor on HA 2026.8

### DIFF
--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+import inspect
 import logging
 from typing import Any
 
@@ -130,6 +131,7 @@ async def async_setup_entry(
         )
         from homeassistant.components.history_stats.data import HistoryStats
         from homeassistant.components.history_stats.sensor import HistoryStatsSensor
+        from homeassistant.helpers.device import async_entity_id_to_device
         from homeassistant.helpers.template import Template
 
         start_template = Template(
@@ -171,15 +173,38 @@ async def async_setup_entry(
             # Ensure the coordinator is initialized
             await coordinator.async_config_entry_first_refresh()
             # Create the sensor with the coordinator
-            history_stats_entity = HistoryStatsSensor(
-                hass=hass,
-                coordinator=coordinator,
-                sensor_type=CONF_TYPE_TIME,
-                name=friendly_name,
-                unique_id=f"{entry.entry_id}_{pool_id}_{SENSOR_ELAPSED_FILTRATION}",
-                source_entity_id=f"sensor.iopool_{slugify_pool_name(pool.title)}_{SENSOR_TEMPERATURE}",
-                state_class=SensorStateClass.MEASUREMENT,
+            history_stats_source_entity_id = (
+                f"sensor.iopool_{slugify_pool_name(pool.title)}_{SENSOR_TEMPERATURE}"
             )
+            history_stats_kwargs: dict[str, Any] = {
+                "coordinator": coordinator,
+                "sensor_type": CONF_TYPE_TIME,
+                "name": friendly_name,
+                "unique_id": f"{entry.entry_id}_{pool_id}_{SENSOR_ELAPSED_FILTRATION}",
+                "state_class": SensorStateClass.MEASUREMENT,
+            }
+            # HA 2026.8 (home-assistant/core#177594, merged 2026-07-30) removed
+            # both `hass` and `source_entity_id` from HistoryStatsSensor.__init__
+            # and made every remaining parameter keyword-only, replacing them
+            # with a pre-computed `device` kwarg. This isn't in HA's official
+            # breaking-changes list, since the class is considered internal
+            # API. Only pass the parameters the installed
+            # HistoryStatsSensor.__init__ actually accepts, so this keeps
+            # working before and after that change, without pinning a version.
+            history_stats_params = inspect.signature(
+                HistoryStatsSensor.__init__
+            ).parameters
+            if "hass" in history_stats_params:
+                history_stats_kwargs["hass"] = hass
+            if "source_entity_id" in history_stats_params:
+                history_stats_kwargs["source_entity_id"] = (
+                    history_stats_source_entity_id
+                )
+            elif "device" in history_stats_params:
+                history_stats_kwargs["device"] = async_entity_id_to_device(
+                    hass, history_stats_source_entity_id
+                )
+            history_stats_entity = HistoryStatsSensor(**history_stats_kwargs)
             history_stats_entity.entity_id = f"sensor.iopool_{slugify_pool_name(pool.title)}_{SENSOR_ELAPSED_FILTRATION}"
             # Add the entity to Home Assistant
             async_add_entities([history_stats_entity])

--- a/custom_components/iopool/tests/test_sensor.py
+++ b/custom_components/iopool/tests/test_sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from custom_components.iopool.const import DOMAIN
+from custom_components.iopool.const import SENSOR_ELAPSED_FILTRATION, DOMAIN
 from custom_components.iopool.sensor import (
     POOL_SENSORS,
     IopoolSensor,
@@ -13,10 +13,13 @@ from custom_components.iopool.sensor import (
 )
 import pytest
 
+from homeassistant.components.history_stats.sensor import HistoryStatsSensor
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import TEST_API_KEY, TEST_POOL_ID, TEST_POOL_TITLE
 
@@ -373,6 +376,104 @@ class TestAsyncSetupEntryEdgeCases:
         hs_call_kwargs = mock_history_stats.call_args[1]
         assert hs_call_kwargs.get("min_state_duration") == timedelta(0)
         assert mock_async_add_entities.call_count >= 1
+
+    @pytest.mark.asyncio
+    @patch("homeassistant.helpers.template.Template")
+    @patch(
+        "homeassistant.components.history_stats.coordinator.HistoryStatsUpdateCoordinator"
+    )
+    @patch("homeassistant.components.history_stats.data.HistoryStats")
+    async def test_async_setup_entry_history_stats_sensor_is_really_constructed(
+        self,
+        mock_history_stats,
+        mock_coordinator_class,
+        mock_template,
+        tmp_path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Regression test for home-assistant/core#177594 (merged 2026-07-30,
+        shipped in HA 2026.8.0): HistoryStatsSensor.__init__ dropped both
+        `hass` and `source_entity_id`, and made the remaining parameters
+        keyword-only.
+
+        Unlike test_async_setup_entry_with_switch_entity above, this test
+        does NOT patch HistoryStatsSensor itself. Constructing it for real is
+        the whole point: a mocked class accepts any kwargs, so it can never
+        catch a TypeError raised by a real, incompatible __init__ signature
+        -- which is exactly why the earlier test kept passing while the
+        elapsed_filtration_duration sensor silently failed to appear on HA
+        2026.8+ (async_setup_entry swallows the TypeError via its
+        `except (ValueError, KeyError, TypeError)` clause and only logs it).
+
+        Also uses a real `homeassistant.core.HomeAssistant` instance with
+        device/entity registries loaded, not the MagicMock `hass` fixture
+        from conftest.py, since the fix's `device=` fallback (for HA 2026.8+)
+        calls the real `async_entity_id_to_device`, which needs a real
+        registry to query.
+        """
+        real_hass = HomeAssistant(str(tmp_path))
+        real_hass.data[dr.DATA_REGISTRY] = dr.DeviceRegistry(real_hass)
+        await dr.async_load(real_hass, load_empty=True)
+        await er.async_load(real_hass, load_empty=True)
+
+        config_entry = ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain=DOMAIN,
+            title=TEST_POOL_TITLE,
+            data={
+                "api_key": TEST_API_KEY,
+                "pool_id": TEST_POOL_ID,
+            },
+            options={},
+            source="user",
+            unique_id=TEST_POOL_ID,
+            discovery_keys=frozenset(),
+            subentries_data={},
+        )
+
+        mock_pool = MagicMock()
+        mock_pool.id = TEST_POOL_ID
+        mock_pool.title = "Test Pool"
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.get_pool_data.return_value = mock_pool
+
+        mock_config = MagicMock()
+        mock_config.options.filtration.get.return_value = "switch.pool_pump"
+
+        mock_runtime_data = MagicMock()
+        mock_runtime_data.coordinator = mock_coordinator
+        mock_runtime_data.config = mock_config
+        config_entry.runtime_data = mock_runtime_data
+
+        mock_template.return_value = MagicMock()
+
+        mock_history_coordinator = MagicMock()
+        mock_history_coordinator.async_config_entry_first_refresh = AsyncMock(
+            return_value=None
+        )
+        mock_coordinator_class.return_value = mock_history_coordinator
+
+        mock_async_add_entities = MagicMock()
+
+        await async_setup_entry(real_hass, config_entry, mock_async_add_entities)
+
+        assert "Failed to set up history_stats sensor" not in caplog.text
+
+        # First call adds POOL_SENSORS; second call (only reached if
+        # HistoryStatsSensor construction didn't raise) adds the real
+        # history_stats entity.
+        assert mock_async_add_entities.call_count == 2
+        added_entities = mock_async_add_entities.call_args_list[1][0][0]
+        assert len(added_entities) == 1
+        history_stats_entity = added_entities[0]
+
+        assert isinstance(history_stats_entity, HistoryStatsSensor)
+        assert (
+            history_stats_entity.unique_id
+            == f"{config_entry.entry_id}_{TEST_POOL_ID}_{SENSOR_ELAPSED_FILTRATION}"
+        )
 
     @pytest.mark.asyncio
     @patch("homeassistant.helpers.template.Template")


### PR DESCRIPTION
## Summary

`home-assistant/core#177594` ("Do not set a device on YAML history_stats entities", merged 2026-07-30, shipped in **HA 2026.8.0 on 2026-08-05**) removed both `hass` and `source_entity_id` from `HistoryStatsSensor.__init__` and made every remaining parameter keyword-only:

```python
# HA 2026.7.x
def __init__(self, hass, *, coordinator, sensor_type, name, unique_id, source_entity_id, state_class): ...

# HA 2026.8.0
def __init__(self, *, coordinator, sensor_type, name, unique_id, state_class, device=None): ...
```

`async_setup_entry()` in `custom_components/iopool/sensor.py:174-182` always calls `HistoryStatsSensor(hass=hass, ..., source_entity_id=..., ...)`. On HA 2026.8+ this raises `TypeError: HistoryStatsSensor.__init__() got an unexpected keyword argument 'hass'`.

**This isn't in HA's official breaking-changes list** — `HistoryStatsSensor` is a helper base class, not a public integration, so core maintainers treat its constructor as internal API. It won't show up in any changelog integration authors watch.

**It's a silent failure, not a crash**: the `TypeError` is caught by the existing `except (ValueError, KeyError, TypeError)` around this block (`sensor.py:186-187`) and only logged as an error — so `async_setup_entry` itself doesn't fail, but the `elapsed_filtration_duration` sensor silently stops being created on every HA 2026.8+ install with a filtration switch entity configured. This repo has been bitten by breaking changes to this exact class twice before (#53/#54, #57/#58 for HA 2026.3/2026.4), so it seemed worth getting ahead of before user reports come in.

## Fix

Build the `HistoryStatsSensor` kwargs conditionally via `inspect.signature()`, forwarding `hass` and `source_entity_id` only when the installed class's `__init__` still accepts them, and falling back to the new `device=` kwarg (computed via the same `async_entity_id_to_device` helper core itself now uses) when it doesn't — so device grouping for this sensor keeps working on both sides of the change, not just the TypeError:

```python
history_stats_params = inspect.signature(HistoryStatsSensor.__init__).parameters
if "hass" in history_stats_params:
    history_stats_kwargs["hass"] = hass
if "source_entity_id" in history_stats_params:
    history_stats_kwargs["source_entity_id"] = history_stats_source_entity_id
elif "device" in history_stats_params:
    history_stats_kwargs["device"] = async_entity_id_to_device(hass, history_stats_source_entity_id)
history_stats_entity = HistoryStatsSensor(**history_stats_kwargs)
```

Scoped to the one call site; no other logic in `async_setup_entry` touched.

## A note on the existing test coverage

`test_async_setup_entry_with_switch_entity` (and its French-locale sibling) already exercised this call site, but both `@patch("homeassistant.components.history_stats.sensor.HistoryStatsSensor")` — replacing the real class with a `MagicMock` before asserting on the kwargs it received. A `MagicMock` accepts any keyword argument, so those tests kept passing through this entire bug; they only verify *what* gets passed, never whether the real class would *accept* it.

I left those two tests untouched (they're still valid for what they check) and added a new one, `test_async_setup_entry_history_stats_sensor_is_really_constructed`, that does **not** mock `HistoryStatsSensor` — it lets the real class run, using a real `homeassistant.core.HomeAssistant()` instance with device/entity registries loaded (not the `MagicMock(spec=HomeAssistant)` fixture from `conftest.py`), since the fix's `device=` fallback calls the real `async_entity_id_to_device`, which needs a real registry to query. **I confirmed this test fails against the unfixed source** with the exact production error:

```
ERROR custom_components.iopool.sensor:sensor.py:187 Failed to set up history_stats sensor: HistoryStatsSensor.__init__() got an unexpected keyword argument 'hass'
```

...while all other 27 pre-existing tests in `test_sensor.py`, including the two mocked ones above, kept passing against that same unfixed source — confirming they wouldn't have caught this on their own.

## Precedent

Same shape of fix for the same upstream change (`hass` removed from a HA helper-entity `__init__`, guarded via `inspect.signature`), merged elsewhere in the HACS ecosystem this week: `woopstar/hsem#716`, `kamaradclimber/heishamon-homeassistant#389`, `kamaradclimber/geovelo-homeassistant#33`, `TarasKhust/ecoflow-api-mqtt#71`. `bramstroker/homeassistant-powercalc` and `Olen/homeassistant-plant#500` already carry their own version-independent guard for this general class of change.

## Tests

```
python -m pytest custom_components/iopool/tests/ -v
```
- Baseline (`git stash`, unmodified `dev`): 291 passed
- New test only, unfixed source: 1 failed (the exact `TypeError` above), 291 passed
- New test + fix: ✅ 292 passed, ❌ 0 failed, ⚠️ 0 errors

`flake8 --max-line-length=150 custom_components/iopool/sensor.py custom_components/iopool/tests/test_sensor.py`: clean.

## What I validated / didn't

- Validated: the exact `TypeError` reproduction against unfixed code, the fix resolving it, the full existing suite staying green, and lint.
- Not validated: I don't have a live iopool pool/switch entity or HA instance to click through the UI with — this is construction-level test coverage only, not a manual end-to-end run. I also didn't test against a real HA 2026.4–2026.7 install (the pre-2026.8 `hass`-required shape); that direction is only covered by the existing (now-verified-blind-but-still-checking-argument-values) mocked tests plus the fact that the `if "hass" in ...` / `if "source_entity_id" in ...` branches are unconditionally exercised whenever a HistoryStatsSensor accepting them is installed.

---

## Commits

- `a0f73f6` fix(sensor): 🐛 Stop dropping the history_stats sensor on HA 2026.8

## Related Issues

None filed yet for this specific break — opening this ahead of user reports, similar to the previous #53/#57 History Stats compatibility fixes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Note: this fix (code, tests, and PR description) was authored with Claude Code (Anthropic). I've reviewed it and validated the test results above myself. (I'm an external contributor working from a fork with the standard `gh` CLI / GitHub UI — not one of this repo's own Copilot coding agents, so the MCP-tool-only rule in `.github/skills/git-conventions/SKILL.md` doesn't apply to how this PR was opened.)
