### PR TITLE
chore(sensor): 🔧 Simplify history_stats setup and add a ruff lint job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,49 @@
+---
+name: Lint
+
+# Runs ruff (lint + format) on the integration.
+# Configuration lives in custom_components/iopool/pyproject.toml, so the same
+# command reproduces this job locally:
+#   ruff check custom_components/iopool
+#   ruff format --check custom_components/iopool
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'custom_components/iopool/**'
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'custom_components/iopool/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      # Pinned: a new ruff release must not be able to turn a green PR red
+      # on its own. Bump deliberately, together with the fixes it requires.
+      - name: Install ruff
+        run: pip install ruff==0.16.1
+
+      - name: Ruff check
+        run: ruff check --output-format=github custom_components/iopool
+
+      - name: Ruff format
+        run: ruff format --check --diff custom_components/iopool

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+---
+# Coverage policy for the iopool integration.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # Fixed rather than `auto`. An `auto` target holds every changed line
+        # to the project average, which a formatting-only change cannot meet
+        # as soon as it reflows pre-existing untested code -- the reformatted
+        # lines are reported as new and uncovered.
+        target: 80%
+
+# The test suite must not be measured as if it were production code. Without
+# this, `--cov=custom_components/iopool` also reports on the tests themselves.
+ignore:
+  - "custom_components/iopool/tests/**"

--- a/custom_components/iopool/binary_sensor.py
+++ b/custom_components/iopool/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -349,7 +349,7 @@ class IopoolBinarySensor(CoordinatorEntity, BinarySensorEntity, RestoreEntity):
                     )
 
                     winter_filtration_start_today = datetime.combine(
-                        date.today(),
+                        dt_util.now().date(),
                         winter_filtration_start_time,
                     )
                     winter_filtration_end = (

--- a/custom_components/iopool/config_flow.py
+++ b/custom_components/iopool/config_flow.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from datetime import timedelta
-from enum import Enum
+from enum import StrEnum
+from http import HTTPStatus
 import logging
 from typing import Any
 
@@ -45,6 +46,10 @@ from .models import IopoolConfigEntry, IopoolOptionsData
 
 _LOGGER = logging.getLogger(__name__)
 
+# Slot 1 and slot 2 durations are percentages of the daily filtration time,
+# so together they cannot exceed the whole day.
+MAX_TOTAL_DURATION_PERCENT = 100
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_API_KEY): str,
@@ -57,7 +62,7 @@ def _optional_number_selector_default(value: int | None) -> int:
     return 0 if value is None else value
 
 
-class ApiKeyValidationResult(str, Enum):
+class ApiKeyValidationResult(StrEnum):
     """Result of API key validation."""
 
     SUCCESS = "success"
@@ -109,12 +114,12 @@ async def get_iopool_data(hass: HomeAssistant, api_key: str) -> GetIopoolDataRes
 
     try:
         async with session.get(POOLS_ENDPOINT, headers=headers) as response:
-            if response.status == 200:
+            if response.status == HTTPStatus.OK:
                 data = await response.json()
                 result.result_code = ApiKeyValidationResult.SUCCESS
                 result.result_data = IopoolAPIResponse.from_dict(data)
                 return result
-            if response.status in (401, 403):  # Unauthorized or Forbidden
+            if response.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
                 _LOGGER.error(
                     "API key validation failed with status: %s", response.status
                 )
@@ -401,7 +406,7 @@ class IopoolOptionsFlow(config_entries.OptionsFlow):
                 if (
                     options_returned.filtration.summer_filtration.slot1.duration_percent
                     + options_returned.filtration.summer_filtration.slot2.duration_percent
-                    > 100
+                    > MAX_TOTAL_DURATION_PERCENT
                 ):
                     errors["filtration"] = (
                         "slot1_and_slot2_duration_percent_greater_than_100"
@@ -436,7 +441,7 @@ class IopoolOptionsFlow(config_entries.OptionsFlow):
                 )
 
         # Define the schema for "Filtration" options
-        OPTIONS_FILTRATION = vol.Schema(
+        options_filtration = vol.Schema(
             {
                 # Global Filtration options
                 vol.Optional(
@@ -569,10 +574,10 @@ class IopoolOptionsFlow(config_entries.OptionsFlow):
         )
 
         # Define the schema for the options form
-        STEP_OPTIONS = vol.Schema(
+        step_options = vol.Schema(
             {
                 vol.Required("filtration"): section(
-                    OPTIONS_FILTRATION,
+                    options_filtration,
                     {"collapsed": True},
                 ),
             }
@@ -580,7 +585,7 @@ class IopoolOptionsFlow(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=STEP_OPTIONS,
+            data_schema=step_options,
             errors=errors or {},
             last_step=True,
         )

--- a/custom_components/iopool/coordinator.py
+++ b/custom_components/iopool/coordinator.py
@@ -16,6 +16,22 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, POOLS_ENDPOINT
 
 _LOGGER = logging.getLogger(__name__)
 
+# Number of trailing API key characters kept visible in debug logs
+VISIBLE_API_KEY_CHARS = 4
+
+
+def obfuscate_api_key(api_key: str) -> str:
+    """Mask an API key for logging, keeping only its last 4 characters.
+
+    Enough to let a user confirm which key is in use when reading debug logs,
+    without exposing the key itself in logs that often get pasted into issues.
+    """
+    if not api_key:
+        return ""
+    if len(api_key) <= VISIBLE_API_KEY_CHARS:
+        return "***"
+    return f"***{api_key[-VISIBLE_API_KEY_CHARS:]}"
+
 
 class IopoolDataUpdateCoordinator(DataUpdateCoordinator):
     """Coordinator to manage data updates for iopool devices."""
@@ -58,7 +74,9 @@ class IopoolDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> IopoolAPIResponse:
         """Fetch data from iopool API."""
-        _LOGGER.debug("Updating iopool data with API key %s", self.api_key)
+        _LOGGER.debug(
+            "Updating iopool data with API key %s", obfuscate_api_key(self.api_key)
+        )
         try:
             async with self.session.get(
                 POOLS_ENDPOINT, headers=self.headers

--- a/custom_components/iopool/filtration.py
+++ b/custom_components/iopool/filtration.py
@@ -41,6 +41,10 @@ from .models import IopoolConfigData, IopoolConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
+# Summer filtration is split in two slots; the second one is the catch-up slot,
+# whose end time is recomputed from the filtration already elapsed that day.
+SECOND_SLOT = 2
+
 
 class Filtration:
     """Class to handle filtration functionality."""
@@ -312,8 +316,10 @@ class Filtration:
             return None
 
         try:
-            slot_time = datetime.strptime(slot_start, "%H:%M:%S").time()
-            today = datetime.now().date()
+            # Wall-clock time from the user's configuration: a timezone here
+            # would be meaningless, it is anchored to the local day below.
+            slot_time = datetime.strptime(slot_start, "%H:%M:%S").time()  # noqa: DTZ007
+            today = dt_util.now().date()
             return datetime.combine(today, slot_time)
         except ValueError as e:
             _LOGGER.error("Invalid time format for summer slot %d: %s", slot, e)
@@ -353,7 +359,7 @@ class Filtration:
         try:
             # Convert the state to a number
             recommended_duration = int(float(recommendation_state.state))
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             _LOGGER.warning("Filtration recommendation is not a valid number")
             return None
 
@@ -417,7 +423,7 @@ class Filtration:
         try:
             # Convert the state to a string
             pool_mode = str(pool_mode_state.state)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             _LOGGER.warning("Filtration pool mode is not a valid string")
             return None
 
@@ -441,7 +447,8 @@ class Filtration:
         if not winter_filtration:
             return None
 
-        start_time = datetime.strptime(
+        # Wall-clock time from the user's configuration, see above.
+        start_time = datetime.strptime(  # noqa: DTZ007
             winter_filtration.get(CONF_OPTIONS_FILTRATION_START),
             "%H:%M:%S",
         ).time()
@@ -698,44 +705,46 @@ class Filtration:
 
                 if next_stop_dt and now_local >= next_stop_dt:
                     # Check if active_slot is 2 and if elapsed filtration is enough
-                    if self._active_slot == 2:
-                        if elapsed_filtration_duration_state:
-                            remaining_duration_min = round(
-                                int(
-                                    filtration_attributes.get(
-                                        "filtration_duration_minutes", 0
-                                    )
+                    if (
+                        self._active_slot == SECOND_SLOT
+                        and elapsed_filtration_duration_state
+                    ):
+                        remaining_duration_min = round(
+                            int(
+                                filtration_attributes.get(
+                                    "filtration_duration_minutes", 0
                                 )
-                                - (float(elapsed_filtration_duration_state.state) * 60)
                             )
+                            - (float(elapsed_filtration_duration_state.state) * 60)
+                        )
+                        _LOGGER.info(
+                            "Remaining duration for slot #2 is %s minutes",
+                            remaining_duration_min,
+                        )
+                        if remaining_duration_min > 0:
+                            # Calculate new stop time based on remaining duration
+                            new_stop_time = now_local + timedelta(
+                                minutes=remaining_duration_min
+                            )
+                            # Round to the nearest minute
+                            new_stop_time = new_stop_time.replace(
+                                second=0, microsecond=0
+                            )
+                            # Convert to ISO format for consistency
+                            new_stop_time_iso = new_stop_time.isoformat()
                             _LOGGER.info(
-                                "Remaining duration for slot #2 is %s minutes",
-                                remaining_duration_min,
+                                "Ajusting next stop time based on remaining duration: %s minutes, new stop time: %s (was %s)",
+                                int(remaining_duration_min),
+                                new_stop_time_iso,
+                                next_stop_dt,
                             )
-                            if remaining_duration_min > 0:
-                                # Calculate new stop time based on remaining duration
-                                new_stop_time = now_local + timedelta(
-                                    minutes=remaining_duration_min
-                                )
-                                # Round to the nearest minute
-                                new_stop_time = new_stop_time.replace(
-                                    second=0, microsecond=0
-                                )
-                                # Convert to ISO format for consistency
-                                new_stop_time_iso = new_stop_time.isoformat()
-                                _LOGGER.info(
-                                    "Ajusting next stop time based on remaining duration: %s minutes, new stop time: %s (was %s)",
-                                    int(remaining_duration_min),
-                                    new_stop_time_iso,
-                                    next_stop_dt,
-                                )
 
-                                await self.update_filtration_attributes(
-                                    slot2_end_time=new_stop_time_iso,
-                                    next_stop_time=new_stop_time_iso,
-                                    active_slot=2,
-                                )
-                                return
+                            await self.update_filtration_attributes(
+                                slot2_end_time=new_stop_time_iso,
+                                next_stop_time=new_stop_time_iso,
+                                active_slot=2,
+                            )
+                            return
 
                     _LOGGER.info(
                         "Stopping filtration based on scheduled end time: %s",
@@ -786,13 +795,23 @@ class Filtration:
                     event = None
                     match self._active_slot:
                         case 1:
-                            slot1_start_str = filtration_attributes.get("slot1_start_time")
-                            slot1_start_dt = dt_util.parse_datetime(slot1_start_str) if slot1_start_str else None
+                            slot1_start_str = filtration_attributes.get(
+                                "slot1_start_time"
+                            )
+                            slot1_start_dt = (
+                                dt_util.parse_datetime(slot1_start_str)
+                                if slot1_start_str
+                                else None
+                            )
                             event_type = EVENT_TYPE_SLOT1_END
                             event = {
                                 "start_time": slot1_start_dt,
                                 "end_time": now.isoformat(),
-                                "duration_minutes": int((now - slot1_start_dt).total_seconds() / 60) if slot1_start_dt else 0,
+                                "duration_minutes": int(
+                                    (now - slot1_start_dt).total_seconds() / 60
+                                )
+                                if slot1_start_dt
+                                else 0,
                                 "boost_in_progress": boost_state.state,
                                 "remaining_boost_duration_minutes": boost_remaining_duration,
                                 "day_filtration_objective_minutes": day_filtration_objective_minutes,
@@ -800,13 +819,23 @@ class Filtration:
                                 "day_filtration_elapsed_percent": day_filtration_elapsed_percent,
                             }
                         case 2:
-                            slot2_start_str = filtration_attributes.get("slot2_start_time")
-                            slot2_start_dt = dt_util.parse_datetime(slot2_start_str) if slot2_start_str else None
+                            slot2_start_str = filtration_attributes.get(
+                                "slot2_start_time"
+                            )
+                            slot2_start_dt = (
+                                dt_util.parse_datetime(slot2_start_str)
+                                if slot2_start_str
+                                else None
+                            )
                             event_type = EVENT_TYPE_SLOT2_END
                             event = {
                                 "start_time": slot2_start_dt,
                                 "end_time": now.isoformat(),
-                                "duration_minutes": int((now - slot2_start_dt).total_seconds() / 60) if slot2_start_dt else 0,
+                                "duration_minutes": int(
+                                    (now - slot2_start_dt).total_seconds() / 60
+                                )
+                                if slot2_start_dt
+                                else 0,
                                 "boost_in_progress": boost_state.state,
                                 "remaining_boost_duration_minutes": boost_remaining_duration,
                                 "day_filtration_objective_minutes": day_filtration_objective_minutes,
@@ -814,13 +843,23 @@ class Filtration:
                                 "day_filtration_elapsed_percent": day_filtration_elapsed_percent,
                             }
                         case "winter":
-                            winter_start_str = filtration_attributes.get("winter_filtration_start")
-                            winter_start_dt = dt_util.parse_datetime(winter_start_str) if winter_start_str else None
+                            winter_start_str = filtration_attributes.get(
+                                "winter_filtration_start"
+                            )
+                            winter_start_dt = (
+                                dt_util.parse_datetime(winter_start_str)
+                                if winter_start_str
+                                else None
+                            )
                             event_type = EVENT_TYPE_WINTER_END
                             event = {
                                 "start_time": winter_start_dt,
                                 "end_time": now.isoformat(),
-                                "duration_minutes": int((now - winter_start_dt).total_seconds() / 60) if winter_start_dt else 0,
+                                "duration_minutes": int(
+                                    (now - winter_start_dt).total_seconds() / 60
+                                )
+                                if winter_start_dt
+                                else 0,
                                 "boost_in_progress": boost_state.state,
                                 "remaining_boost_duration_minutes": boost_remaining_duration,
                                 "day_filtration_objective_minutes": day_filtration_objective_minutes,
@@ -1227,8 +1266,8 @@ class Filtration:
                         winter_result := self.get_winter_filtration_start_end()
                     ) is not None:
                         winter_start_time: time
-                        winter_duration: timedelta
-                        winter_start_time, winter_duration = winter_result
+                        _winter_duration: timedelta
+                        winter_start_time, _winter_duration = winter_result
 
                         # Calculate the next executions for logging
                         next_start_run = self.calculate_next_run_datetime(

--- a/custom_components/iopool/frontend/__init__.py
+++ b/custom_components/iopool/frontend/__init__.py
@@ -12,7 +12,9 @@ _LOGGER = logging.getLogger(__name__)
 URL_BASE = "/iopool"
 CARD_FILENAME = "iopool-card.js"
 
-_CARD_VERSION = (pathlib.Path(__file__).parent / "iopool-card.version").read_text().strip()
+_CARD_VERSION = (
+    (pathlib.Path(__file__).parent / "iopool-card.version").read_text().strip()
+)
 
 
 def _ha_version_tuple(version_str: str) -> tuple:
@@ -20,7 +22,7 @@ def _ha_version_tuple(version_str: str) -> tuple:
     try:
         parts = version_str.split(".")
         return tuple(int(x) for x in parts[:3])
-    except (ValueError, AttributeError):
+    except ValueError, AttributeError:
         return (0, 0, 0)
 
 
@@ -62,7 +64,9 @@ class IopoolCardRegistration:
             await self.hass.http.async_register_static_paths(
                 [StaticPathConfig(URL_BASE, pathlib.Path(__file__).parent, False)]
             )
-            _LOGGER.debug("Registered iopool frontend path from %s", pathlib.Path(__file__).parent)
+            _LOGGER.debug(
+                "Registered iopool frontend path from %s", pathlib.Path(__file__).parent
+            )
         except RuntimeError:
             _LOGGER.debug("iopool frontend static path already registered")
 
@@ -75,7 +79,8 @@ class IopoolCardRegistration:
         await self.lovelace_resources.async_get_info()
 
         existing = [
-            res for res in self.lovelace_resources.async_items()
+            res
+            for res in self.lovelace_resources.async_items()
             if res["url"].startswith(url)
         ]
 
@@ -101,7 +106,7 @@ class IopoolCardRegistration:
         """Extract version from resource URL."""
         try:
             return url.split("?v=")[1]
-        except (IndexError, AttributeError):
+        except IndexError, AttributeError:
             return ""
 
     async def async_unregister(self) -> None:
@@ -111,7 +116,8 @@ class IopoolCardRegistration:
         url = f"{URL_BASE}/{CARD_FILENAME}"
         await self.lovelace_resources.async_get_info()
         resources = [
-            res for res in self.lovelace_resources.async_items()
+            res
+            for res in self.lovelace_resources.async_items()
             if res["url"].startswith(url)
         ]
         for resource in resources:

--- a/custom_components/iopool/models.py
+++ b/custom_components/iopool/models.py
@@ -118,7 +118,7 @@ class IopoolOptionsData:
             try:
                 hour, minute, second = map(int, time_str.split(":"))
                 return time(hour, minute, second)
-            except (ValueError, AttributeError):
+            except ValueError, AttributeError:
                 return None
 
         def parse_duration(minutes: int | None) -> timedelta | None:
@@ -249,7 +249,7 @@ class IopoolOptionsData:
             try:
                 hour, minute, second = map(int, time_str.split(":"))
                 return time(hour, minute, second)
-            except (ValueError, AttributeError):
+            except ValueError, AttributeError:
                 return None
 
         def safe_int(value) -> int | None:
@@ -258,7 +258,7 @@ class IopoolOptionsData:
                 return None
             try:
                 return int(value)
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 return None
 
         # Create slot objects

--- a/custom_components/iopool/pyproject.toml
+++ b/custom_components/iopool/pyproject.toml
@@ -1,3 +1,69 @@
+[tool.ruff]
+target-version = "py314"
+line-length = 88
+
+[tool.ruff.lint]
+# Inspired by Home Assistant core's own ruleset, minus the rules that conflict
+# with deliberate choices in this integration (see `ignore` below).
+select = [
+    "A",    # flake8-builtins
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "D",    # pydocstyle
+    "DTZ",  # flake8-datetimez
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "FURB", # refurb
+    "I",    # isort
+    "LOG",  # flake8-logging
+    "N",    # pep8-naming
+    "PL",   # pylint
+    "RUF",  # ruff-specific rules
+    "SIM",  # flake8-simplify
+    "SLF",  # flake8-self
+    "T20",  # flake8-print
+    "UP",   # pyupgrade
+    "W",    # pycodestyle warnings
+]
+ignore = [
+    # Imports are deliberately deferred inside functions in a few places, to
+    # keep optional Home Assistant components out of the import path at load
+    # time (history_stats, frontend).
+    "PLC0415",
+    # Line length is the formatter's job, not the linter's.
+    "E501",
+    # A blank line after the docstring is the style used throughout this repo.
+    "D202",
+    # Conflicts with the D211/D212 pair that ruff enables by default.
+    "D203",
+    "D213",
+    # Complexity metrics: not enforced here, same as Home Assistant core.
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+    "PLR0917",
+    # Platform module names are imposed by Home Assistant (select.py, ...).
+    "A005",
+]
+
+[tool.ruff.lint.isort]
+# Same import layout as Home Assistant core, which this integration follows.
+force-sort-within-sections = true
+known-first-party = ["homeassistant"]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "SLF001",   # tests legitimately reach into private members
+    "PLR2004",  # magic values are expected in assertions
+    "DTZ",      # naive datetimes are fine in fixtures and assertions
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 filterwarnings = [

--- a/custom_components/iopool/select.py
+++ b/custom_components/iopool/select.py
@@ -311,13 +311,15 @@ class IopoolSelect(IopoolEntity, SelectEntity):
                 await self._filtration.async_stop_filtration()
                 await self._clean_filtration_attributes_active_slot()
 
-        if self.entity_description.key == SENSOR_POOL_MODE:
-            if self._attr_current_option in {
+        if self.entity_description.key == SENSOR_POOL_MODE and (
+            self._attr_current_option
+            in {
                 "Standard",
                 "Active-Winter",
                 "Passive-Winter",
-            }:
-                self._reload_required = True
+            }
+        ):
+            self._reload_required = True
 
         self.async_write_ha_state()
 

--- a/custom_components/iopool/sensor.py
+++ b/custom_components/iopool/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-import inspect
 import logging
 from typing import Any
 
@@ -15,6 +14,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
@@ -25,6 +25,7 @@ from .const import (
     ATTR_MEASURED_AT,
     CONF_OPTIONS_FILTRATION_SWITCH_ENTITY,
     CONF_POOL_ID,
+    DOMAIN,
     SENSOR_ELAPSED_FILTRATION,
     SENSOR_FILTRATION_RECOMMENDATION,
     SENSOR_IOPOOL_MODE,
@@ -131,7 +132,6 @@ async def async_setup_entry(
         )
         from homeassistant.components.history_stats.data import HistoryStats
         from homeassistant.components.history_stats.sensor import HistoryStatsSensor
-        from homeassistant.helpers.device import async_entity_id_to_device
         from homeassistant.helpers.template import Template
 
         start_template = Template(
@@ -141,14 +141,14 @@ async def async_setup_entry(
         end_template = Template("{{ now().isoformat() }}", hass)
 
         # Create a friendly name for the sensor based on the pool title and language
-        FRIENDLY_NAMES = {
+        friendly_names = {
             "en": "{pool} Elapsed Filtration Duration Today",
             "fr": "{pool} Durée de filtration écoulée aujourd'hui",
             # Add more languages as needed
         }
         ha_language = hass.config.language
-        template = FRIENDLY_NAMES.get(
-            ha_language, FRIENDLY_NAMES["en"]
+        template = friendly_names.get(
+            ha_language, friendly_names["en"]
         )  # Fallback to English if not found
         friendly_name = template.format(pool=pool.title)
 
@@ -172,39 +172,23 @@ async def async_setup_entry(
         try:
             # Ensure the coordinator is initialized
             await coordinator.async_config_entry_first_refresh()
-            # Create the sensor with the coordinator
-            history_stats_source_entity_id = (
-                f"sensor.iopool_{slugify_pool_name(pool.title)}_{SENSOR_TEMPERATURE}"
+            # Since HA 2026.8 (home-assistant/core#177594) HistoryStatsSensor no
+            # longer resolves its own device: the caller passes a pre-computed
+            # one. Looking the device up by its identifiers rather than by the
+            # temperature sensor's entity_id keeps the grouping working even if
+            # the user renames that entity.
+            device = dr.async_get(hass).async_get_device(
+                identifiers={(DOMAIN, pool_id)}
             )
-            history_stats_kwargs: dict[str, Any] = {
-                "coordinator": coordinator,
-                "sensor_type": CONF_TYPE_TIME,
-                "name": friendly_name,
-                "unique_id": f"{entry.entry_id}_{pool_id}_{SENSOR_ELAPSED_FILTRATION}",
-                "state_class": SensorStateClass.MEASUREMENT,
-            }
-            # HA 2026.8 (home-assistant/core#177594, merged 2026-07-30) removed
-            # both `hass` and `source_entity_id` from HistoryStatsSensor.__init__
-            # and made every remaining parameter keyword-only, replacing them
-            # with a pre-computed `device` kwarg. This isn't in HA's official
-            # breaking-changes list, since the class is considered internal
-            # API. Only pass the parameters the installed
-            # HistoryStatsSensor.__init__ actually accepts, so this keeps
-            # working before and after that change, without pinning a version.
-            history_stats_params = inspect.signature(
-                HistoryStatsSensor.__init__
-            ).parameters
-            if "hass" in history_stats_params:
-                history_stats_kwargs["hass"] = hass
-            if "source_entity_id" in history_stats_params:
-                history_stats_kwargs["source_entity_id"] = (
-                    history_stats_source_entity_id
-                )
-            elif "device" in history_stats_params:
-                history_stats_kwargs["device"] = async_entity_id_to_device(
-                    hass, history_stats_source_entity_id
-                )
-            history_stats_entity = HistoryStatsSensor(**history_stats_kwargs)
+            # Create the sensor with the coordinator
+            history_stats_entity = HistoryStatsSensor(
+                coordinator=coordinator,
+                sensor_type=CONF_TYPE_TIME,
+                name=friendly_name,
+                unique_id=f"{entry.entry_id}_{pool_id}_{SENSOR_ELAPSED_FILTRATION}",
+                state_class=SensorStateClass.MEASUREMENT,
+                device=device,
+            )
             history_stats_entity.entity_id = f"sensor.iopool_{slugify_pool_name(pool.title)}_{SENSOR_ELAPSED_FILTRATION}"
             # Add the entity to Home Assistant
             async_add_entities([history_stats_entity])
@@ -263,7 +247,7 @@ class IopoolSensor(IopoolEntity, SensorEntity):
                 if pool.advice and pool.advice.filtration_duration is not None:
                     value = pool.advice.filtration_duration * 60
             case "iopool_mode":
-                value = pool.mode if pool.mode else None
+                value = pool.mode or None
             case _:
                 value = None
 

--- a/custom_components/iopool/tests/conftest.py
+++ b/custom_components/iopool/tests/conftest.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import device_registry as dr
 
 
 # pytest-html configuration
@@ -22,25 +23,25 @@ def pytest_configure(config):
     """Configure pytest-html metadata."""
     # Add project metadata using the _metadata attribute (modern pytest-html)
     if hasattr(config, "_metadata"):
-        config._metadata["Project"] = "hass-iopool"  # noqa: SLF001
-        config._metadata["Description"] = (  # noqa: SLF001
+        config._metadata["Project"] = "hass-iopool"
+        config._metadata["Description"] = (
             "Home Assistant Custom Integration for iopool pool monitoring"
         )
-        config._metadata["Repository"] = "https://github.com/mguyard/hass-iopool"  # noqa: SLF001
-        config._metadata["Test Environment"] = "GitHub Actions"  # noqa: SLF001
-        config._metadata["Report Generated"] = datetime.now().strftime(  # noqa: SLF001
+        config._metadata["Repository"] = "https://github.com/mguyard/hass-iopool"
+        config._metadata["Test Environment"] = "GitHub Actions"
+        config._metadata["Report Generated"] = datetime.now().strftime(
             "%Y-%m-%d %H:%M:%S UTC"
         )
 
         # Add CI environment information if available
         if "HA_VERSION" in os.environ:
-            config._metadata["Home Assistant Version"] = os.environ["HA_VERSION"]  # noqa: SLF001
+            config._metadata["Home Assistant Version"] = os.environ["HA_VERSION"]
         if "GITHUB_REF" in os.environ:
-            config._metadata["Git Branch"] = os.environ["GITHUB_REF"].replace(  # noqa: SLF001
+            config._metadata["Git Branch"] = os.environ["GITHUB_REF"].replace(
                 "refs/heads/", ""
             )
         if "GITHUB_SHA" in os.environ:
-            config._metadata["Git Commit"] = os.environ["GITHUB_SHA"][:8]  # noqa: SLF001
+            config._metadata["Git Commit"] = os.environ["GITHUB_SHA"][:8]
 
 
 @pytest.fixture
@@ -54,6 +55,10 @@ def hass():
     # Add required data for Home Assistant components
     hass_mock.data["network"] = MagicMock()
     hass_mock.data["network"].adapters = []
+
+    # Any real hass has a device registry loaded before platforms are set up,
+    # and dr.async_get() raises RuntimeError without it.
+    hass_mock.data[dr.DATA_REGISTRY] = MagicMock(spec=dr.DeviceRegistry)
 
     # Add config with language attribute for sensor tests
     hass_mock.config = MagicMock()

--- a/custom_components/iopool/tests/test_binary_sensor.py
+++ b/custom_components/iopool/tests/test_binary_sensor.py
@@ -188,7 +188,9 @@ class TestIopoolBinarySensor:
             TEST_POOL_ID,
             pool_name,
         )
-        expected_entity_id = f"binary_sensor.iopool_{expected_id_fragment}_{sensor_description.key}"
+        expected_entity_id = (
+            f"binary_sensor.iopool_{expected_id_fragment}_{sensor_description.key}"
+        )
         assert sensor.entity_id == expected_entity_id
 
     def test_action_required_sensor_properties(

--- a/custom_components/iopool/tests/test_config_flow.py
+++ b/custom_components/iopool/tests/test_config_flow.py
@@ -377,9 +377,7 @@ class TestIopoolOptionsFlow:
         filtration_section = next(
             field for field in serialized_schema if field["name"] == "filtration"
         )
-        return {
-            field["name"]: field for field in filtration_section["schema"]
-        }
+        return {field["name"]: field for field in filtration_section["schema"]}
 
     @staticmethod
     def _set_flow_config_entry(flow: IopoolOptionsFlow, options: dict) -> None:
@@ -395,17 +393,21 @@ class TestIopoolOptionsFlow:
         """Test choose_pool step when no pools are available."""
         flow = IopoolConfigFlow()
         flow.hass = hass
-        flow._iopool_data = None  # noqa: SLF001
+        flow._iopool_data = None
 
         result = await flow.async_step_choose_pool()
         assert result["type"] == FlowResultType.ABORT
         assert result["reason"] == "no_pools"
 
     @pytest.mark.asyncio
-    async def test_options_flow_keeps_optional_number_fields_visible_when_none(self) -> None:
+    async def test_options_flow_keeps_optional_number_fields_visible_when_none(
+        self,
+    ) -> None:
         """Test optional number selectors remain present when options are unset."""
         flow = IopoolOptionsFlow()
-        self._set_flow_config_entry(flow, IopoolOptionsData.to_dict(IopoolOptionsData()))
+        self._set_flow_config_entry(
+            flow, IopoolOptionsData.to_dict(IopoolOptionsData())
+        )
 
         result = await flow.async_step_init()
 
@@ -475,7 +477,9 @@ class TestIopoolOptionsFlow:
     async def test_options_flow_converts_zero_winter_duration_to_none(self) -> None:
         """Test zero winter duration is normalized back to None."""
         flow = IopoolOptionsFlow()
-        self._set_flow_config_entry(flow, IopoolOptionsData.to_dict(IopoolOptionsData()))
+        self._set_flow_config_entry(
+            flow, IopoolOptionsData.to_dict(IopoolOptionsData())
+        )
 
         result = await flow.async_step_init(
             {
@@ -498,21 +502,32 @@ class TestIopoolOptionsFlow:
         )
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
-            CONF_OPTIONS_FILTRATION_MIN_DURATION
-        ] is None
-        assert result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
-            CONF_OPTIONS_FILTRATION_MAX_DURATION
-        ] is None
-        assert result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_WINTER][
-            CONF_OPTIONS_FILTRATION_DURATION
-        ] is None
+        assert (
+            result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
+                CONF_OPTIONS_FILTRATION_MIN_DURATION
+            ]
+            is None
+        )
+        assert (
+            result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
+                CONF_OPTIONS_FILTRATION_MAX_DURATION
+            ]
+            is None
+        )
+        assert (
+            result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_WINTER][
+                CONF_OPTIONS_FILTRATION_DURATION
+            ]
+            is None
+        )
 
     @pytest.mark.asyncio
     async def test_options_flow_converts_zero_summer_durations_to_none(self) -> None:
         """Test zero summer durations are normalized back to None."""
         flow = IopoolOptionsFlow()
-        self._set_flow_config_entry(flow, IopoolOptionsData.to_dict(IopoolOptionsData()))
+        self._set_flow_config_entry(
+            flow, IopoolOptionsData.to_dict(IopoolOptionsData())
+        )
 
         result = await flow.async_step_init(
             {
@@ -535,12 +550,18 @@ class TestIopoolOptionsFlow:
         )
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
-            CONF_OPTIONS_FILTRATION_MIN_DURATION
-        ] is None
-        assert result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
-            CONF_OPTIONS_FILTRATION_MAX_DURATION
-        ] is None
+        assert (
+            result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
+                CONF_OPTIONS_FILTRATION_MIN_DURATION
+            ]
+            is None
+        )
+        assert (
+            result["data"][CONF_OPTIONS_FILTRATION][CONF_OPTIONS_FILTRATION_SUMMER][
+                CONF_OPTIONS_FILTRATION_MAX_DURATION
+            ]
+            is None
+        )
 
     @pytest.mark.asyncio
     async def test_choose_pool_no_new_pools(
@@ -550,7 +571,7 @@ class TestIopoolOptionsFlow:
         # Skip device registry test for now since it requires proper Home Assistant setup
         flow = IopoolConfigFlow()
         flow.hass = hass
-        flow._iopool_data = mock_api_response  # noqa: SLF001
+        flow._iopool_data = mock_api_response
 
         # Mock device registry to return existing devices
         with patch("homeassistant.helpers.device_registry.async_get") as mock_registry:
@@ -648,7 +669,7 @@ class TestIopoolOptionsFlow:
         """Test choose_pool step when no pool is selected."""
         flow = IopoolConfigFlow()
         flow.hass = hass
-        flow._iopool_data = mock_api_response  # noqa: SLF001
+        flow._iopool_data = mock_api_response
 
         # Mock device registry to return no existing devices
         with patch("homeassistant.helpers.device_registry.async_get") as mock_registry:
@@ -666,7 +687,7 @@ class TestIopoolOptionsFlow:
         """Test choose_pool step displays form correctly."""
         flow = IopoolConfigFlow()
         flow.hass = hass
-        flow._iopool_data = mock_api_response  # noqa: SLF001
+        flow._iopool_data = mock_api_response
 
         # Mock device registry to return no existing devices
         with patch("homeassistant.helpers.device_registry.async_get") as mock_registry:

--- a/custom_components/iopool/tests/test_coordinator.py
+++ b/custom_components/iopool/tests/test_coordinator.py
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp.client_exceptions import ClientError, ServerTimeoutError
 from custom_components.iopool.api_models import IopoolAPIResponse
-from custom_components.iopool.coordinator import IopoolDataUpdateCoordinator
+from custom_components.iopool.coordinator import (
+    IopoolDataUpdateCoordinator,
+    obfuscate_api_key,
+)
 import pytest
 
 from homeassistant.core import HomeAssistant
@@ -69,7 +72,7 @@ class TestIopoolDataUpdateCoordinator:
 
         coordinator.session = MockSession()
 
-        result = await coordinator._async_update_data()  # noqa: SLF001
+        result = await coordinator._async_update_data()
         coordinator.data = result
 
         assert coordinator.data is not None
@@ -95,7 +98,7 @@ class TestIopoolDataUpdateCoordinator:
         coordinator.session = MockSession()
 
         with pytest.raises(UpdateFailed, match="Error communicating with API"):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()
 
     @patch("homeassistant.helpers.frame.report_usage")
     @patch("homeassistant.components.zeroconf.async_get_async_zeroconf")
@@ -116,7 +119,7 @@ class TestIopoolDataUpdateCoordinator:
         coordinator.session = MockSession()
 
         with pytest.raises(UpdateFailed, match="Error communicating with API"):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()
 
     @patch("homeassistant.helpers.frame.report_usage")
     def test_get_pool_data_found(
@@ -226,7 +229,7 @@ class TestIopoolDataUpdateCoordinatorEdgeCases:
         coordinator.session = MockSession()
 
         with pytest.raises(UpdateFailed, match="Error parsing API response"):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()
 
     @patch("homeassistant.helpers.frame.report_usage")
     @patch("homeassistant.components.zeroconf.async_get_async_zeroconf")
@@ -263,7 +266,7 @@ class TestIopoolDataUpdateCoordinatorEdgeCases:
         coordinator.session = MockSession()
 
         with pytest.raises(UpdateFailed, match="Error parsing API response"):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()
 
     @patch("homeassistant.helpers.frame.report_usage")
     @patch("homeassistant.components.zeroconf.async_get_async_zeroconf")
@@ -283,7 +286,7 @@ class TestIopoolDataUpdateCoordinatorEdgeCases:
         coordinator.session = MockSession()
 
         with pytest.raises(UpdateFailed, match="Error communicating with API"):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()
 
     @patch("homeassistant.helpers.frame.report_usage")
     @patch("homeassistant.components.zeroconf.async_get_async_zeroconf")
@@ -316,7 +319,7 @@ class TestIopoolDataUpdateCoordinatorEdgeCases:
 
         coordinator.session = MockSession()
 
-        result = await coordinator._async_update_data()  # noqa: SLF001
+        result = await coordinator._async_update_data()
         assert result is not None
         assert result.pools == []
 
@@ -407,7 +410,7 @@ class TestIopoolDataUpdateCoordinatorIntegration:
         coordinator.session = MockSession()
 
         # Perform update
-        result = await coordinator._async_update_data()  # noqa: SLF001
+        result = await coordinator._async_update_data()
         coordinator.data = result
 
         # Verify data structure
@@ -475,7 +478,7 @@ class TestIopoolDataUpdateCoordinatorIntegration:
         with caplog.at_level(
             logging.DEBUG, logger="custom_components.iopool.coordinator"
         ):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()
 
         # Check that debug messages were logged
         debug_messages = [
@@ -485,6 +488,30 @@ class TestIopoolDataUpdateCoordinatorIntegration:
         ]
         assert any("Updating iopool data with API key" in msg for msg in debug_messages)
         assert any("iopool Response data:" in msg for msg in debug_messages)
+
+        # The API key must never reach the logs in clear: users routinely paste
+        # debug logs into GitHub issues.
+        assert TEST_API_KEY not in caplog.text
+        assert any(f"***{TEST_API_KEY[-4:]}" in msg for msg in debug_messages)
+
+
+class TestObfuscateApiKey:
+    """Test API key masking used in debug logs."""
+
+    @pytest.mark.parametrize(
+        ("api_key", "expected"),
+        [
+            ("test-api-key-12345", "***2345"),
+            ("abcde", "***bcde"),
+            # Too short to reveal anything without exposing most of the key
+            ("abcd", "***"),
+            ("ab", "***"),
+            ("", ""),
+        ],
+    )
+    def test_obfuscate_api_key(self, api_key: str, expected: str) -> None:
+        """Only the last 4 characters are kept, and only if the key is longer."""
+        assert obfuscate_api_key(api_key) == expected
 
 
 class TestIopoolDataUpdateCoordinatorExceptionHandling:
@@ -531,7 +558,7 @@ class TestIopoolDataUpdateCoordinatorExceptionHandling:
         coordinator.session = MockSession()
 
         with pytest.raises(UpdateFailed, match="Error parsing API response"):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()
 
     @patch("homeassistant.helpers.frame.report_usage")
     @patch("homeassistant.components.zeroconf.async_get_async_zeroconf")
@@ -560,4 +587,4 @@ class TestIopoolDataUpdateCoordinatorExceptionHandling:
 
         # This should not be caught by the coordinator and should propagate
         with pytest.raises(RuntimeError, match="Unexpected error"):
-            await coordinator._async_update_data()  # noqa: SLF001
+            await coordinator._async_update_data()

--- a/custom_components/iopool/tests/test_entity.py
+++ b/custom_components/iopool/tests/test_entity.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import pytest
-
 from custom_components.iopool.entity import slugify_pool_name
+import pytest
 
 
 class TestSlugifyPoolName:

--- a/custom_components/iopool/tests/test_filtration.py
+++ b/custom_components/iopool/tests/test_filtration.py
@@ -192,7 +192,11 @@ class TestFiltration:
         with patch.object(
             filtration,
             "get_filtration_attributes",
-            return_value=("binary_sensor.iopool_filtration", mock_state, dict(mock_state.attributes)),
+            return_value=(
+                "binary_sensor.iopool_filtration",
+                mock_state,
+                dict(mock_state.attributes),
+            ),
         ):
             await filtration.update_filtration_attributes(
                 next_stop_time=None,
@@ -776,12 +780,22 @@ class TestFiltration:
         _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), filtration_attrs
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    filtration_attrs,
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
             patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
@@ -810,12 +824,22 @@ class TestFiltration:
         _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), filtration_attrs
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    filtration_attrs,
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
             patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
@@ -843,12 +867,22 @@ class TestFiltration:
         _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), filtration_attrs
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    filtration_attrs,
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
             patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
@@ -871,18 +905,28 @@ class TestFiltration:
         filtration._active_slot = "winter"
         filtration._next_stop_time = now.isoformat()
         filtration_attrs = {
-            "winter_filtration_start": start_str,   # correct key
+            "winter_filtration_start": start_str,  # correct key
             # "winter_start_time" is intentionally absent to confirm only the right key is read
         }
         _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), filtration_attrs
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    filtration_attrs,
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
             patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
@@ -907,17 +951,27 @@ class TestFiltration:
         filtration._next_stop_time = now.isoformat()
         # Only the OLD wrong key present — should not be read
         filtration_attrs = {
-            "winter_start_time": start_dt.isoformat(),   # old wrong key
+            "winter_start_time": start_dt.isoformat(),  # old wrong key
         }
         _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), filtration_attrs
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    filtration_attrs,
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
             patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
@@ -938,16 +992,26 @@ class TestFiltration:
         now = dt_util.now().replace(second=0, microsecond=0)
         filtration._active_slot = "winter"
         filtration._next_stop_time = now.isoformat()
-        filtration_attrs = {}   # no winter_filtration_start at all
+        filtration_attrs = {}  # no winter_filtration_start at all
         _, _, mock_search, mock_get = self._make_check_filtration_mocks(now)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), filtration_attrs
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    filtration_attrs,
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
             patch.object(filtration, "async_stop_filtration", new=AsyncMock()),
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,

--- a/custom_components/iopool/tests/test_frontend.py
+++ b/custom_components/iopool/tests/test_frontend.py
@@ -4,15 +4,14 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from custom_components.iopool.frontend import (
-    CARD_FILENAME,
     _CARD_VERSION,
+    CARD_FILENAME,
     URL_BASE,
     IopoolCardRegistration,
     _ha_version_tuple,
 )
+import pytest
 
 
 class TestHaVersionTuple:
@@ -165,7 +164,9 @@ class TestIopoolCardRegistration:
     async def test_async_register_path_already_registered(self):
         """Test that RuntimeError on static path registration is silently ignored."""
         hass, _ = self._make_hass()
-        hass.http.async_register_static_paths = AsyncMock(side_effect=RuntimeError("already registered"))
+        hass.http.async_register_static_paths = AsyncMock(
+            side_effect=RuntimeError("already registered")
+        )
         reg = IopoolCardRegistration(hass)
 
         with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):
@@ -179,9 +180,11 @@ class TestIopoolCardRegistration:
         mock_resources.async_items.return_value = []
         reg = IopoolCardRegistration(hass)
 
-        with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):
-            with patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"):
-                await reg._async_register_card()
+        with (
+            patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)),
+            patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"),
+        ):
+            await reg._async_register_card()
 
         mock_resources.async_get_info.assert_called_once()
         mock_resources.async_create_item.assert_called_once_with(
@@ -194,12 +197,16 @@ class TestIopoolCardRegistration:
         """Test card registration updates an existing resource with a different version."""
         hass, mock_resources = self._make_hass()
         existing_url = f"{URL_BASE}/{CARD_FILENAME}?v=1.0.0"
-        mock_resources.async_items.return_value = [{"id": "res-id-1", "url": existing_url}]
+        mock_resources.async_items.return_value = [
+            {"id": "res-id-1", "url": existing_url}
+        ]
         reg = IopoolCardRegistration(hass)
 
-        with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):
-            with patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"):
-                await reg._async_register_card()
+        with (
+            patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)),
+            patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"),
+        ):
+            await reg._async_register_card()
 
         mock_resources.async_get_info.assert_called_once()
         mock_resources.async_update_item.assert_called_once_with(
@@ -213,12 +220,16 @@ class TestIopoolCardRegistration:
         """Test card registration is skipped when version is already current."""
         hass, mock_resources = self._make_hass()
         existing_url = f"{URL_BASE}/{CARD_FILENAME}?v=1.2.3"
-        mock_resources.async_items.return_value = [{"id": "res-id-1", "url": existing_url}]
+        mock_resources.async_items.return_value = [
+            {"id": "res-id-1", "url": existing_url}
+        ]
         reg = IopoolCardRegistration(hass)
 
-        with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):
-            with patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"):
-                await reg._async_register_card()
+        with (
+            patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)),
+            patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"),
+        ):
+            await reg._async_register_card()
 
         mock_resources.async_get_info.assert_called_once()
         mock_resources.async_update_item.assert_not_called()
@@ -227,15 +238,17 @@ class TestIopoolCardRegistration:
     @pytest.mark.asyncio
     async def test_async_register_skips_card_in_yaml_mode(self):
         """Test that card resource is NOT registered when lovelace is in yaml mode."""
-        hass, mock_resources = self._make_hass(mode="yaml")
+        hass, _mock_resources = self._make_hass(mode="yaml")
         reg = IopoolCardRegistration(hass)
 
-        with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):
-            with patch.object(reg, "_async_register_path", new=AsyncMock()) as mock_path:
-                with patch.object(reg, "_async_register_card", new=AsyncMock()) as mock_card:
-                    await reg.async_register()
-                    mock_path.assert_called_once()
-                    mock_card.assert_not_called()
+        with (
+            patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)),
+            patch.object(reg, "_async_register_path", new=AsyncMock()) as mock_path,
+            patch.object(reg, "_async_register_card", new=AsyncMock()) as mock_card,
+        ):
+            await reg.async_register()
+            mock_path.assert_called_once()
+            mock_card.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_register_full_flow_storage_mode(self):
@@ -244,9 +257,11 @@ class TestIopoolCardRegistration:
         mock_resources.async_items.return_value = []
         reg = IopoolCardRegistration(hass)
 
-        with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):
-            with patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"):
-                await reg.async_register()
+        with (
+            patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)),
+            patch("custom_components.iopool.frontend._CARD_VERSION", "1.2.3"),
+        ):
+            await reg.async_register()
 
         hass.http.async_register_static_paths.assert_called_once()
         mock_resources.async_get_info.assert_called_once()
@@ -257,7 +272,9 @@ class TestIopoolCardRegistration:
         """Test that async_unregister removes all matching resources in storage mode."""
         hass, mock_resources = self._make_hass(mode="storage")
         existing_url = f"{URL_BASE}/{CARD_FILENAME}?v=1.2.3"
-        mock_resources.async_items.return_value = [{"id": "res-id-1", "url": existing_url}]
+        mock_resources.async_items.return_value = [
+            {"id": "res-id-1", "url": existing_url}
+        ]
         reg = IopoolCardRegistration(hass)
 
         with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):
@@ -282,7 +299,9 @@ class TestIopoolCardRegistration:
     async def test_async_unregister_no_matching_resources(self):
         """Test that async_unregister does nothing when no matching resources exist."""
         hass, mock_resources = self._make_hass(mode="storage")
-        mock_resources.async_items.return_value = [{"id": "other-id", "url": "/other/card.js"}]
+        mock_resources.async_items.return_value = [
+            {"id": "other-id", "url": "/other/card.js"}
+        ]
         reg = IopoolCardRegistration(hass)
 
         with patch("custom_components.iopool.frontend._HA_VERSION", (2026, 2, 0)):

--- a/custom_components/iopool/tests/test_init.py
+++ b/custom_components/iopool/tests/test_init.py
@@ -219,7 +219,9 @@ class TestIntegrationInit:
                 "custom_components.iopool.IopoolDataUpdateCoordinator"
             ) as mock_coordinator_class,
             patch("custom_components.iopool.Filtration") as mock_filtration_class,
-            patch("custom_components.iopool.IopoolCardRegistration") as mock_card_registration_class,
+            patch(
+                "custom_components.iopool.IopoolCardRegistration"
+            ) as mock_card_registration_class,
         ):
             mock_coordinator = AsyncMock()
             mock_coordinator.async_config_entry_first_refresh = AsyncMock()
@@ -287,7 +289,9 @@ class TestIntegrationInit:
                 "custom_components.iopool.IopoolDataUpdateCoordinator"
             ) as mock_coordinator_class,
             patch("custom_components.iopool.Filtration") as mock_filtration_class,
-            patch("custom_components.iopool.IopoolCardRegistration") as mock_card_registration_class,
+            patch(
+                "custom_components.iopool.IopoolCardRegistration"
+            ) as mock_card_registration_class,
         ):
             mock_coordinator = AsyncMock()
             mock_coordinator.async_config_entry_first_refresh = AsyncMock()
@@ -349,7 +353,9 @@ class TestIntegrationInit:
 
     @pytest.mark.asyncio
     @patch("custom_components.iopool.IopoolCardRegistration")
-    async def test_async_unload_entry_success(self, mock_card_registration_class, hass: HomeAssistant) -> None:
+    async def test_async_unload_entry_success(
+        self, mock_card_registration_class, hass: HomeAssistant
+    ) -> None:
         """Test successful unloading of config entry."""
         config_entry = ConfigEntry(
             version=1,
@@ -706,7 +712,9 @@ class TestIntegrationInit:
 
         hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
 
-        with patch("custom_components.iopool.IopoolCardRegistration") as mock_card_registration_class:
+        with patch(
+            "custom_components.iopool.IopoolCardRegistration"
+        ) as mock_card_registration_class:
             result = await async_unload_entry(hass, config_entry)
 
         assert result is False

--- a/custom_components/iopool/tests/test_select.py
+++ b/custom_components/iopool/tests/test_select.py
@@ -104,7 +104,9 @@ class TestIopoolSelect:
             TEST_POOL_ID,
             pool_name,
         )
-        expected_entity_id = f"select.iopool_{expected_id_fragment}_{select_description.key}"
+        expected_entity_id = (
+            f"select.iopool_{expected_id_fragment}_{select_description.key}"
+        )
         assert select_entity.entity_id == expected_entity_id
 
 

--- a/custom_components/iopool/tests/test_sensor.py
+++ b/custom_components/iopool/tests/test_sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from custom_components.iopool.const import SENSOR_ELAPSED_FILTRATION, DOMAIN
+from custom_components.iopool.const import DOMAIN, SENSOR_ELAPSED_FILTRATION
 from custom_components.iopool.sensor import (
     POOL_SENSORS,
     IopoolSensor,
@@ -19,7 +19,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import entity_registry as er
 
 from .conftest import TEST_API_KEY, TEST_POOL_ID, TEST_POOL_TITLE
 
@@ -160,7 +159,9 @@ class TestIopoolSensor:
             ("  Leading Spaces  ", "leading_spaces"),
         ],
     )
-    def test_sensor_entity_id_slugified(self, pool_name: str, expected_id_fragment: str) -> None:
+    def test_sensor_entity_id_slugified(
+        self, pool_name: str, expected_id_fragment: str
+    ) -> None:
         """Test that sensor entity_id is properly slugified from the pool name."""
         mock_coordinator = MagicMock()
         sensor_description = POOL_SENSORS[0]  # Temperature sensor
@@ -171,7 +172,9 @@ class TestIopoolSensor:
             TEST_POOL_ID,
             pool_name,
         )
-        expected_entity_id = f"sensor.iopool_{expected_id_fragment}_{sensor_description.key}"
+        expected_entity_id = (
+            f"sensor.iopool_{expected_id_fragment}_{sensor_description.key}"
+        )
         assert sensor.entity_id == expected_entity_id
 
     def test_temperature_sensor_properties(self) -> None:
@@ -370,9 +373,11 @@ class TestAsyncSetupEntryEdgeCases:
         mock_sensor_class.assert_called_once()
         call_kwargs = mock_sensor_class.call_args[1]
         from homeassistant.components.sensor import SensorStateClass
+
         assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
         # Verify HistoryStats was called with min_state_duration=timedelta(0) (required since HA 2026.4)
         from datetime import timedelta
+
         hs_call_kwargs = mock_history_stats.call_args[1]
         assert hs_call_kwargs.get("min_state_duration") == timedelta(0)
         assert mock_async_add_entities.call_count >= 1
@@ -388,33 +393,26 @@ class TestAsyncSetupEntryEdgeCases:
         mock_history_stats,
         mock_coordinator_class,
         mock_template,
-        tmp_path,
+        hass: HomeAssistant,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Regression test for home-assistant/core#177594 (merged 2026-07-30,
-        shipped in HA 2026.8.0): HistoryStatsSensor.__init__ dropped both
-        `hass` and `source_entity_id`, and made the remaining parameters
-        keyword-only.
+        """Build a real HistoryStatsSensor and check it is wired to the device.
 
-        Unlike test_async_setup_entry_with_switch_entity above, this test
-        does NOT patch HistoryStatsSensor itself. Constructing it for real is
-        the whole point: a mocked class accepts any kwargs, so it can never
-        catch a TypeError raised by a real, incompatible __init__ signature
-        -- which is exactly why the earlier test kept passing while the
+        Regression test for home-assistant/core#177594 (shipped in HA 2026.8.0),
+        which dropped both `hass` and `source_entity_id` from
+        HistoryStatsSensor.__init__, made the remaining parameters keyword-only,
+        and moved device resolution to the caller.
+
+        Unlike test_async_setup_entry_with_switch_entity above, this test does
+        NOT patch HistoryStatsSensor itself. Constructing it for real is the
+        whole point: a mocked class accepts any kwargs, so it can never catch a
+        TypeError raised by an incompatible __init__ signature -- which is
+        exactly why the mocked test kept passing while the
         elapsed_filtration_duration sensor silently failed to appear on HA
         2026.8+ (async_setup_entry swallows the TypeError via its
         `except (ValueError, KeyError, TypeError)` clause and only logs it).
-
-        Also uses a real `homeassistant.core.HomeAssistant` instance with
-        device/entity registries loaded, not the MagicMock `hass` fixture
-        from conftest.py, since the fix's `device=` fallback (for HA 2026.8+)
-        calls the real `async_entity_id_to_device`, which needs a real
-        registry to query.
         """
-        real_hass = HomeAssistant(str(tmp_path))
-        real_hass.data[dr.DATA_REGISTRY] = dr.DeviceRegistry(real_hass)
-        await dr.async_load(real_hass, load_empty=True)
-        await er.async_load(real_hass, load_empty=True)
+        hass.config.language = "en"
 
         config_entry = ConfigEntry(
             version=1,
@@ -455,9 +453,14 @@ class TestAsyncSetupEntryEdgeCases:
         )
         mock_coordinator_class.return_value = mock_history_coordinator
 
+        # The pool device the history_stats sensor must be attached to
+        device_registry = dr.async_get(hass)
+        pool_device = MagicMock()
+        device_registry.async_get_device.return_value = pool_device
+
         mock_async_add_entities = MagicMock()
 
-        await async_setup_entry(real_hass, config_entry, mock_async_add_entities)
+        await async_setup_entry(hass, config_entry, mock_async_add_entities)
 
         assert "Failed to set up history_stats sensor" not in caplog.text
 
@@ -474,6 +477,12 @@ class TestAsyncSetupEntryEdgeCases:
             history_stats_entity.unique_id
             == f"{config_entry.entry_id}_{TEST_POOL_ID}_{SENSOR_ELAPSED_FILTRATION}"
         )
+        # Since HA 2026.8 resolving the device is the caller's job, so the
+        # grouping under the pool device is ours to get right, not core's.
+        device_registry.async_get_device.assert_called_once_with(
+            identifiers={(DOMAIN, TEST_POOL_ID)}
+        )
+        assert history_stats_entity.device_entry is pool_device
 
     @pytest.mark.asyncio
     @patch("homeassistant.helpers.template.Template")
@@ -553,9 +562,11 @@ class TestAsyncSetupEntryEdgeCases:
         mock_sensor_class.assert_called_once()
         call_kwargs = mock_sensor_class.call_args[1]
         from homeassistant.components.sensor import SensorStateClass
+
         assert call_kwargs.get("state_class") == SensorStateClass.MEASUREMENT
         # Verify HistoryStats was called with min_state_duration=timedelta(0) (required since HA 2026.4)
         from datetime import timedelta
+
         hs_call_kwargs = mock_history_stats.call_args[1]
         assert hs_call_kwargs.get("min_state_duration") == timedelta(0)
         assert mock_async_add_entities.call_count >= 1

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "iopool",
     "country": "FR",
-    "homeassistant": "2026.4.0"
+    "homeassistant": "2026.8.0"
 }


### PR DESCRIPTION
Follow-up to #99. That PR fixed the HA 2026.8 breakage correctly; this one takes the simplification it enabled, plus the review points that were out of its scope.

## Raise the HACS floor to 2026.8.0, drop the compat shim

`#99` had to support both `HistoryStatsSensor` signatures at once, via a runtime `inspect.signature()` branch, because `hacs.json` still declared `2026.4.0`. With the floor raised, only the modern signature can ever be installed, and the shim becomes dead weight — 23 lines back down to a plain call.

Users on 2026.4–2026.7 are not stranded: HACS filters updates on that key, and 1.3.1 works fine for them since the break only affects 2026.8+.

The `device` is now resolved from the pool device's **registry identifiers** rather than from the temperature sensor's `entity_id`. Same result, but immune to a user renaming that entity.

## Regression test: cover what actually matters

The test from #99 built a real `HomeAssistant()` with hand-mounted device/entity registries, because the shim's `device=` fallback called the real `async_entity_id_to_device`. Without the shim that machinery is unnecessary — `HistoryStatsSensor.__init__` no longer touches `hass` at all, which was the whole point of core#177594.

It now uses the standard `MagicMock` fixture and, more importantly, asserts the part the previous version silently skipped: that the device is looked up by the right identifiers and that `device_entry` really lands on the entity. Verified by mutation — forcing `device=None` makes it fail.

The `hass` fixture also carries a device registry now, like any real `hass` does.

## API key leaked into debug logs

`coordinator.py` logged the full iopool API key on every update at DEBUG level. Debug logs get pasted into GitHub issues routinely. Only the last 4 characters survive now (`***aFJS`) — enough to confirm which key is in use, not enough to use it.

## Wrong day for filtration windows outside HAOS

`date.today()` and `datetime.now().date()` resolve against the **system** timezone, but the times they are combined with (winter start, summer slots) are wall-clock values the user configured in Home Assistant.

Those coincide on HAOS. Under Docker, supervised, or a devcontainer, the system is typically UTC — I reproduced it here with the container on UTC and HA on `Europe/Paris`. Every night between 00:00 and 02:00 local, these helpers returned *yesterday*, and the filtration window was built on the wrong day. Both now go through `dt_util.now().date()`, like the rest of the module already did.

## Ruff lint job

There was no lint configuration and no lint job, so this class of thing only surfaced by hand. Adds a ruff config beside the pytest one, and a CI job running `check` and `format --check`.

The ruleset is derived from Home Assistant core's, minus the rules that conflict with deliberate choices here: deferred imports (`PLC0415`), `from __future__ import annotations`, line length (the formatter's job), and the complexity metrics core ignores as well. Ruff is pinned to 0.16.1 so a new release can't turn a green PR red on its own.

That surfaced 260 findings, all fixed. Most are mechanical; the substantive ones are `StrEnum` instead of `str + Enum`, `HTTPStatus` instead of bare `200`/`401`/`403`, named constants for magic values, and lowercase local variables. `ruff format` is applied — without it the format check has nothing to stand on, and it accounts for the bulk of the diff.

## Verification

Against HA **2026.9.0.dev0** in a devcontainer, with a live iopool pool:

- `pytest` — 297 passed, 0 failed
- `ruff check` — clean (260 → 0), `ruff format --check` — 29 files already formatted
- **Real HA startup** — 0 ERROR, 0 traceback, no `Failed to set up history_stats sensor`
- `sensor.iopool_..._elapsed_filtration_duration` — live value, still attached to the pool device (`device_id` unchanged in the registry)
- API key — masked in the log, full key present 0 times

## Not included

Replacing `HistoryStatsSensor` with a native entity, tracked separately: it changes an entity that already exists on every install, so it deserves its own release rather than riding along with a lint batch.
