### PR TITLE
chore(ci): 🔧 Render refactor commits in release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install semantic-release
-        run: npm install -g semantic-release @semantic-release/github @semantic-release/commit-analyzer @semantic-release/git @semantic-release/release-notes-generator @semantic-release/changelog semantic-release-replace-plugin
+        run: npm install -g semantic-release @semantic-release/github @semantic-release/commit-analyzer @semantic-release/git @semantic-release/release-notes-generator @semantic-release/changelog semantic-release-replace-plugin conventional-changelog-conventionalcommits@9
       - name: Release
         id: semantic
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -6,9 +6,114 @@
             "prerelease": true
         }
     ],
+    "preset": "conventionalcommits",
     "plugins": [
-        "@semantic-release/commit-analyzer",
-        "@semantic-release/release-notes-generator",
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "presetConfig": {
+                    "types": [
+                        {
+                            "type": "feat",
+                            "section": "✨ Features"
+                        },
+                        {
+                            "type": "fix",
+                            "section": "🐛 Bug Fixes"
+                        },
+                        {
+                            "type": "perf",
+                            "section": "⚡ Performance Improvements"
+                        },
+                        {
+                            "type": "refactor",
+                            "section": "♻️ Code Refactoring"
+                        },
+                        {
+                            "type": "revert",
+                            "section": "⏪ Reverts"
+                        },
+                        {
+                            "type": "docs",
+                            "hidden": true
+                        },
+                        {
+                            "type": "style",
+                            "hidden": true
+                        },
+                        {
+                            "type": "test",
+                            "hidden": true
+                        },
+                        {
+                            "type": "build",
+                            "hidden": true
+                        },
+                        {
+                            "type": "ci",
+                            "hidden": true
+                        },
+                        {
+                            "type": "chore",
+                            "hidden": true
+                        }
+                    ]
+                }
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "presetConfig": {
+                    "types": [
+                        {
+                            "type": "feat",
+                            "section": "✨ Features"
+                        },
+                        {
+                            "type": "fix",
+                            "section": "🐛 Bug Fixes"
+                        },
+                        {
+                            "type": "perf",
+                            "section": "⚡ Performance Improvements"
+                        },
+                        {
+                            "type": "refactor",
+                            "section": "♻️ Code Refactoring"
+                        },
+                        {
+                            "type": "revert",
+                            "section": "⏪ Reverts"
+                        },
+                        {
+                            "type": "docs",
+                            "hidden": true
+                        },
+                        {
+                            "type": "style",
+                            "hidden": true
+                        },
+                        {
+                            "type": "test",
+                            "hidden": true
+                        },
+                        {
+                            "type": "build",
+                            "hidden": true
+                        },
+                        {
+                            "type": "ci",
+                            "hidden": true
+                        },
+                        {
+                            "type": "chore",
+                            "hidden": true
+                        }
+                    ]
+                }
+            }
+        ],
         [
             "@semantic-release/changelog",
             {
@@ -18,13 +123,15 @@
         [
             "semantic-release-replace-plugin",
             {
-              "replacements": [
-                {
-                  "files": ["custom_components/iopool/manifest.json"],
-                  "from": "\"version\": \".*\"",
-                  "to": "\"version\": \"${nextRelease.version}\""
-                }
-              ]
+                "replacements": [
+                    {
+                        "files": [
+                            "custom_components/iopool/manifest.json"
+                        ],
+                        "from": "\"version\": \".*\"",
+                        "to": "\"version\": \"${nextRelease.version}\""
+                    }
+                ]
             }
         ],
         "@semantic-release/github",


### PR DESCRIPTION
Refs #104.

## Why

The default angular preset renders only `feat`, `fix`, `perf` and reverts. Everything else is invisible. #102 replaces the implementation of `sensor.<pool>_elapsed_filtration_duration` — an entity present on every install with a filtration switch — and would have shipped in v1.3.2 with **no mention at all** in the changelog, because its commit is typed `refactor:`.

## What

Switches to the `conventionalcommits` preset (the only one supporting `presetConfig`) and declares the **full** type list explicitly instead of relying on defaults: `feat`, `fix`, `perf`, `refactor`, `revert` rendered, the rest hidden.

Declaring every type matters — the two presets disagree on their defaults. Angular renders `perf`; conventionalcommits hides it. Relying on defaults would have silently dropped a section.

## The v10 trap

`conventional-changelog-conventionalcommits` is pinned to **v9**.

v10 targets `conventional-changelog-writer@9` while `release-notes-generator` still ships v8. The result is that `generateNotes` emits only the version header — every section disappears, and the release publishes an **empty changelog without erroring**. The version bump is unaffected, so nothing fails loudly.

Tracked upstream in [semantic-release/release-notes-generator#992](https://github.com/semantic-release/release-notes-generator/issues/992), opened 2026-06-28, **still open**. The semantic-release maintainer's guidance is explicit:

> the proper resolution to this is to avoid upgrading your dependency on `conventional-changelog-conventionalcommits` to v10 until the semantic-release ecosystem has been upgraded to support it

`release.yaml` installed the package unpinned, so CI would have resolved v10.3.0 (released 4 days ago) and published v1.3.2 with empty release notes. I hit exactly that during validation before finding the upstream issue.

| Preset version | Entries rendered |
|---|---|
| 10.3.0 | **0 — empty notes** |
| 9.3.1 | 5 |
| 8.0.0 | 5 |
| 7.0.2 | 25 — nothing hidden |

v9.3.1 dates from 2026-03-29 and is the last release of the maintained line, not an abandoned branch.

## Validation

Two `semantic-release --dry-run` passes over a **local simulation of the `dev → beta` merge** (temporary branch off `beta` with `dev` merged in, configured as a prerelease branch), same commit set both times:

| | Current config | This PR |
|---|---|---|
| Version | 1.3.2-beta.1 | 1.3.2-beta.1 — identical |
| Bump | patch | patch — identical |
| Sections | `Bug Fixes` (5) | `🐛 Bug Fixes` (5) + `♻️ Code Refactoring` (2) |

The identical bump is the point worth stating: it was the one question documentation could not settle, since the conventionalcommits preset ships its own `whatBump`. Answered empirically rather than by reading source.

Notes produced by this PR:

```
### 🐛 Bug Fixes
* **coordinator:** 🐛 Obfuscate the API key in debug logs
* **filtration:** 🐛 Use the Home Assistant timezone for today
* **iopool-card:** update iopool-card to v1.2.0
* **iopool-card:** update iopool-card to v1.2.0-beta.1
* **sensor:** 🐛 Stop dropping the history_stats sensor on HA 2026.8 (#99)

### ♻️ Code Refactoring
* **sensor:** ♻️ Drop the HistoryStatsSensor compat shim
* **sensor:** ♻️ Implement the elapsed filtration sensor natively
```

Two caveats on the simulation, for the record:

- The prerelease number is not faithful — it reads `beta.1` rather than the `beta.3` the real run will produce. Prerelease counters are tied to the channel/tag association of the actual `beta` branch, which a temporary branch cannot reproduce. The rendering, which is what this PR changes, is faithful.
- The `closes [57/#58]` link on the second refactor commit renders as a broken cross-repo reference. That comes from `#57/#58` appearing in my own commit body, not from this configuration. Cosmetic, not worth rewriting history over.

## Also worth knowing

`chore(deps)` commits stay hidden, so Dependabot noise does not reach the changelog. `docs` is hidden too — flip it to a section if you would rather surface documentation changes to users.
