### PR TITLE
fix(filtration): stop the pump when the elapsed-duration sensor is unavailable

### DIFF
--- a/custom_components/iopool/filtration.py
+++ b/custom_components/iopool/filtration.py
@@ -4,6 +4,7 @@ from datetime import datetime, time, timedelta
 import logging
 import re
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
@@ -703,11 +704,25 @@ class Filtration:
                     elapsed_filtration_duration_state,
                 )
 
+                # A sensor entity that exists but reads "unavailable"/"unknown"
+                # is truthy as a State object, unlike one that was never found
+                # (None). Both mean "no usable elapsed-duration reading right
+                # now", but only the None case short-circuited below before
+                # this guard -- the special-state one reached float() and
+                # raised, aborting the whole check silently and leaving the
+                # pump running past its scheduled stop.
+                elapsed_filtration_duration_usable = bool(
+                    elapsed_filtration_duration_state
+                ) and elapsed_filtration_duration_state.state not in (
+                    STATE_UNAVAILABLE,
+                    STATE_UNKNOWN,
+                )
+
                 if next_stop_dt and now_local >= next_stop_dt:
                     # Check if active_slot is 2 and if elapsed filtration is enough
                     if (
                         self._active_slot == SECOND_SLOT
-                        and elapsed_filtration_duration_state
+                        and elapsed_filtration_duration_usable
                     ):
                         remaining_duration_min = round(
                             int(
@@ -764,7 +779,7 @@ class Filtration:
                     )
                     day_filtration_elapsed_minutes = (
                         float(elapsed_filtration_duration_state.state) * 60
-                        if elapsed_filtration_duration_state
+                        if elapsed_filtration_duration_usable
                         else 0
                     )
                     day_filtration_elapsed_percent = round(

--- a/custom_components/iopool/tests/test_filtration.py
+++ b/custom_components/iopool/tests/test_filtration.py
@@ -18,6 +18,7 @@ from custom_components.iopool.const import (
     CONF_OPTIONS_FILTRATION_WINTER,
     DOMAIN,
     EVENT_TYPE_SLOT1_END,
+    EVENT_TYPE_SLOT2_END,
     EVENT_TYPE_WINTER_END,
 )
 from custom_components.iopool.filtration import Filtration
@@ -1023,3 +1024,231 @@ class TestFiltration:
         event_payload = mock_publish.call_args[0][1]
         assert event_payload["duration_minutes"] == 0
         assert event_payload["start_time"] is None
+
+
+    # ---------------------------------------------------------------------------
+    # check_filtration_status — slot 2 summer catch-up branch (#103)
+    # ---------------------------------------------------------------------------
+
+    def _make_catchup_mocks(self, elapsed_hours: float | str | None):
+        """Mocks with an elapsed-filtration sensor, in addition to switch/boost."""
+        switch_state = MagicMock()
+        switch_state.state = "on"
+        boost_state = MagicMock()
+        boost_state.state = "none"
+        boost_state.attributes = {}
+        elapsed_state = None
+        if elapsed_hours is not None:
+            elapsed_state = MagicMock()
+            elapsed_state.state = str(elapsed_hours)
+
+        def mock_search(platform, pattern):
+            if "boost" in pattern:
+                return "select.boost_selector"
+            if "elapsed_filtration_duration" in pattern:
+                return "sensor.elapsed" if elapsed_state is not None else None
+            return None
+
+        def mock_get(eid):
+            if eid == "switch.pool_pump":
+                return switch_state
+            if eid == "select.boost_selector":
+                return boost_state
+            if eid == "sensor.elapsed":
+                return elapsed_state
+            return None
+
+        return mock_search, mock_get
+
+    async def test_slot2_catchup_pushes_back_stop_time_when_time_is_owed(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """active_slot 2, quota not yet met: push the stop time back, don't stop."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 2
+        filtration._next_stop_time = now.isoformat()
+        # 90 elapsed minutes against a 120-minute objective: 30 owed.
+        mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=90 / 60)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()) as mock_update,
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_stop.assert_not_called()
+        mock_publish.assert_not_called()
+        mock_update.assert_called_once()
+        kwargs = mock_update.call_args.kwargs
+        assert kwargs["active_slot"] == 2
+        expected_stop = (now + timedelta(minutes=30)).replace(second=0, microsecond=0)
+        assert kwargs["next_stop_time"] == expected_stop.isoformat()
+        assert kwargs["slot2_end_time"] == expected_stop.isoformat()
+
+    async def test_slot2_catchup_stops_normally_once_quota_is_met(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """active_slot 2, quota already met: falls through to the normal stop."""
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 2
+        filtration._next_stop_time = now.isoformat()
+        # 120 elapsed minutes against a 120-minute objective: nothing owed.
+        mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=120 / 60)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_stop.assert_called_once()
+        mock_publish.assert_called_once()
+        assert mock_publish.call_args[0][0] == EVENT_TYPE_SLOT2_END
+
+    async def test_slot1_never_enters_the_catchup_branch(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """active_slot 1: the slot-2-only catch-up branch must not engage.
+
+        Even with an elapsed-duration sensor present and quota unmet, slot 1
+        stops on schedule -- the catch-up rule is specific to slot 2.
+        """
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 1
+        filtration._next_stop_time = now.isoformat()
+        mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=10 / 60)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_stop.assert_called_once()
+        mock_publish.assert_called_once()
+        assert mock_publish.call_args[0][0] == EVENT_TYPE_SLOT1_END
+
+    async def test_slot2_catchup_with_missing_sensor_stops_normally(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """active_slot 2, elapsed-duration sensor entity not found at all.
+
+        `elapsed_filtration_duration_state` is `None`, which is falsy, so the
+        catch-up branch's body never runs and this falls through to a normal
+        stop -- distinct from the sensor existing but reading "unavailable",
+        which does not short-circuit the same way (see the next test).
+        """
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 2
+        filtration._next_stop_time = now.isoformat()
+        mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=None)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_stop.assert_called_once()
+        mock_publish.assert_called_once()
+
+    @pytest.mark.parametrize("special_state", ["unavailable", "unknown"])
+    async def test_slot2_catchup_with_special_sensor_state_stops_normally(
+        self, filtration: Filtration, mock_coordinator: MagicMock, special_state: str
+    ) -> None:
+        """active_slot 2, elapsed-duration sensor reads a special HA state.
+
+        The State object is truthy in both cases, so neither can be conflated
+        with the sensor being absent (previous test): float() would raise on
+        either string, and the pump must still stop rather than silently
+        running past its scheduled slot 2 end because of it.
+        """
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 2
+        filtration._next_stop_time = now.isoformat()
+        mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=special_state)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_stop.assert_called_once()
+        mock_publish.assert_called_once()
+
+    async def test_slot2_catchup_boundary_rounds_to_zero_falls_through_to_stop(
+        self, filtration: Filtration, mock_coordinator: MagicMock
+    ) -> None:
+        """remaining_duration_min rounds to exactly 0 at the boundary.
+
+        `round(...) > 0` is the guard, so a remainder that rounds to zero
+        (here: 0.4 real minutes owed) must stop normally, not push back by
+        zero minutes.
+        """
+        now = dt_util.now().replace(second=0, microsecond=0)
+        filtration._active_slot = 2
+        filtration._next_stop_time = now.isoformat()
+        # 119.6 elapsed minutes against 120: 0.4 owed, rounds to 0.
+        mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=119.6 / 60)
+
+        with (
+            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(filtration, "search_entity", side_effect=mock_search),
+            patch.object(filtration, "get_filtration_attributes", return_value=(
+                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
+            )),
+            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
+            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()) as mock_update,
+            patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
+        ):
+            mock_coordinator.hass.states.get.side_effect = mock_get
+            await filtration.check_filtration_status(now)
+
+        mock_stop.assert_called_once()
+        mock_publish.assert_called_once()
+        mock_update.assert_called_once()
+        # The only update call here is the trailing next_stop_time/active_slot
+        # clear, not a slot2_end_time push-back.
+        assert "slot2_end_time" not in mock_update.call_args.kwargs

--- a/custom_components/iopool/tests/test_filtration.py
+++ b/custom_components/iopool/tests/test_filtration.py
@@ -1025,13 +1025,12 @@ class TestFiltration:
         assert event_payload["duration_minutes"] == 0
         assert event_payload["start_time"] is None
 
-
     # ---------------------------------------------------------------------------
     # check_filtration_status — slot 2 summer catch-up branch (#103)
     # ---------------------------------------------------------------------------
 
     def _make_catchup_mocks(self, elapsed_hours: float | str | None):
-        """Mocks with an elapsed-filtration sensor, in addition to switch/boost."""
+        """Build mocks with an elapsed-filtration sensor, in addition to switch/boost."""
         switch_state = MagicMock()
         switch_state.state = "on"
         boost_state = MagicMock()
@@ -1071,14 +1070,28 @@ class TestFiltration:
         mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=90 / 60)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
-            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
-            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()) as mock_update,
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    {"filtration_duration_minutes": 120},
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
+            patch.object(
+                filtration, "async_stop_filtration", new=AsyncMock()
+            ) as mock_stop,
+            patch.object(
+                filtration, "update_filtration_attributes", new=AsyncMock()
+            ) as mock_update,
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
         ):
             mock_coordinator.hass.states.get.side_effect = mock_get
@@ -1104,13 +1117,25 @@ class TestFiltration:
         mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=120 / 60)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
-            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    {"filtration_duration_minutes": 120},
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
+            patch.object(
+                filtration, "async_stop_filtration", new=AsyncMock()
+            ) as mock_stop,
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
         ):
@@ -1135,13 +1160,25 @@ class TestFiltration:
         mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=10 / 60)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
-            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    {"filtration_duration_minutes": 120},
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
+            patch.object(
+                filtration, "async_stop_filtration", new=AsyncMock()
+            ) as mock_stop,
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
         ):
@@ -1168,13 +1205,25 @@ class TestFiltration:
         mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=None)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
-            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    {"filtration_duration_minutes": 120},
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
+            patch.object(
+                filtration, "async_stop_filtration", new=AsyncMock()
+            ) as mock_stop,
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
         ):
@@ -1201,13 +1250,25 @@ class TestFiltration:
         mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=special_state)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
-            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    {"filtration_duration_minutes": 120},
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
+            patch.object(
+                filtration, "async_stop_filtration", new=AsyncMock()
+            ) as mock_stop,
             patch.object(filtration, "update_filtration_attributes", new=AsyncMock()),
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
         ):
@@ -1233,14 +1294,28 @@ class TestFiltration:
         mock_search, mock_get = self._make_catchup_mocks(elapsed_hours=119.6 / 60)
 
         with (
-            patch.object(filtration, "get_switch_entity", return_value="switch.pool_pump"),
+            patch.object(
+                filtration, "get_switch_entity", return_value="switch.pool_pump"
+            ),
             patch.object(filtration, "search_entity", side_effect=mock_search),
-            patch.object(filtration, "get_filtration_attributes", return_value=(
-                "binary_sensor.filtration", MagicMock(), {"filtration_duration_minutes": 120}
-            )),
-            patch.object(filtration, "get_summer_filtration_duration", return_value=120),
-            patch.object(filtration, "async_stop_filtration", new=AsyncMock()) as mock_stop,
-            patch.object(filtration, "update_filtration_attributes", new=AsyncMock()) as mock_update,
+            patch.object(
+                filtration,
+                "get_filtration_attributes",
+                return_value=(
+                    "binary_sensor.filtration",
+                    MagicMock(),
+                    {"filtration_duration_minutes": 120},
+                ),
+            ),
+            patch.object(
+                filtration, "get_summer_filtration_duration", return_value=120
+            ),
+            patch.object(
+                filtration, "async_stop_filtration", new=AsyncMock()
+            ) as mock_stop,
+            patch.object(
+                filtration, "update_filtration_attributes", new=AsyncMock()
+            ) as mock_update,
             patch.object(filtration, "publish_event", new=AsyncMock()) as mock_publish,
         ):
             mock_coordinator.hass.states.get.side_effect = mock_get


### PR DESCRIPTION
Fixes #103, and along the way, a real bug the coverage gap was hiding.

## What was uncovered, and what it turned out to hide

`check_filtration_status`'s slot-2 summer catch-up branch reads
`elapsed_filtration_duration_state.state` and converts it with `float()`.
A sensor entity that exists but currently reads `"unavailable"` or
`"unknown"` is truthy as a `State` object — unlike one that was never
found (`None`), which the existing code already handles safely.

Confirmed by writing the failing test first, per this repo's #103 asking
for exactly that discipline: `float("unavailable")` raises `ValueError`,
which is caught by the function's outer `except (ValueError, TypeError)`.
That logs an error and returns — silently, before `async_stop_filtration()`
is ever reached. The pump keeps running past its scheduled slot 2 end for
as long as that sensor stays unavailable, which HA sensors do transiently
and routinely (a coordinator hiccup, an HA restart). This is exactly the
failure mode #103 warned about:

> it either stops filtration too early... or extends it indefinitely...
> invisible until a user notices their water quality or their electricity
> bill.

The same unguarded `float(elapsed_filtration_duration_state.state)`
appears a second time further down, computing `day_filtration_elapsed_minutes`
for the stop-event payload. It's only reached once the first fix lets
`async_stop_filtration()` actually run, so it surfaced as its own test
failure (`publish_event` never called) once I'd already fixed the first
spot. Both are now covered by one `elapsed_filtration_duration_usable`
flag computed once — following the pattern already used at `filtration.py:356`
for the same class of sensor read (a local `try/except` there; a check
computed up front here, since this call site needs to fall through to a
different branch rather than return `None`).

## Test cases (every one #103 asked for)

- Catch-up pushes the stop time back by exactly the remaining minutes,
  and updates `slot2_end_time`/`next_stop_time`/`active_slot` without
  stopping the pump.
- Quota already met (`remaining_duration_min <= 0`) falls through to a
  normal stop.
- Slot 1 never enters the slot-2-only catch-up branch.
- A missing sensor (`None`) falls through safely — this already worked,
  and the test pins it as distinct from the next case rather than assuming
  it.
- The boundary where the remainder rounds to exactly zero minutes falls
  through to a normal stop rather than pushing back by zero.
- `"unavailable"` / `"unknown"` (parametrised) — the bug above, now fixed.

## Validation

Checked each new test is load-bearing, not just green, by running the
whole file against `main` (`d517a7e`): the two special-state tests are
the only ones that fail there; the other four pass unchanged, confirming
they were testing already-correct behaviour rather than asserting
something new. Ran with Home Assistant installed via `pip install
homeassistant` under Python 3.13 (matches the CI matrix's floor; CI also
runs 3.14) and `PYTHONPATH` pointed at a copy of `custom_components`,
mirroring the workflow's own "Create Home Assistant test environment"
step.

- Full suite: `custom_components/iopool/tests/` — **298 passed** (was 292).
- Coverage: **95%** overall; the catch-up branch's lines are no longer in
  the gap.
- `ruff check` on the changed files: 2 pre-existing findings (`I001`,
  `SIM102`), both present on `main` too and unrelated to this change —
  confirmed by running ruff against `main`'s copy of the same file.
  This repo doesn't run ruff/mypy in CI (only `tests.yaml`), so I checked
  it as a courtesy rather than because it's gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
